### PR TITLE
Fix `clippy::all` warnings in `substrate`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "substrate"]
+	path = substrate
+	url = https://github.com/rockbmb/substrate.git

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -80,5 +80,5 @@ gcr.io/opensourcecoin/radicle-registry       <none>                             
 ```
 
 The new image digest in this case will be
-sha256:264a6e976faeb63adda312cd3ecf2fb9ff71fd6f030128b3f012daf9c4cff05b, as it
+`sha256:264a6e976faeb63adda312cd3ecf2fb9ff71fd6f030128b3f012daf9c4cff05b`, as it
 is the most recently built.


### PR DESCRIPTION
@geigerzaehler WIP, we may decide it's not at all worth it to keep `clippy::all` in CI.