### PR TITLE
Normalize package names in runtime

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -123,10 +123,10 @@ fn testnet_genesis(
             code: WASM_BINARY.to_vec(),
             changes_trie_config: Default::default(),
         }),
-        indices: Some(IndicesConfig {
+        srml_indices: Some(IndicesConfig {
             ids: endowed_accounts.clone(),
         }),
-        balances: Some(BalancesConfig {
+        srml_balances: Some(BalancesConfig {
             balances: endowed_accounts
                 .iter()
                 .cloned()
@@ -134,14 +134,14 @@ fn testnet_genesis(
                 .collect(),
             vesting: vec![],
         }),
-        sudo: Some(SudoConfig { key: root_key }),
-        babe: Some(BabeConfig {
+        srml_sudo: Some(SudoConfig { key: root_key }),
+        srml_babe: Some(BabeConfig {
             authorities: initial_authorities
                 .iter()
                 .map(|x| (x.3.clone(), 1))
                 .collect(),
         }),
-        grandpa: Some(GrandpaConfig {
+        srml_grandpa: Some(GrandpaConfig {
             authorities: initial_authorities
                 .iter()
                 .map(|x| (x.2.clone(), 1))

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,25 +8,25 @@ version = "0.1.0"
 default = ["std"]
 std = [
     "codec/std",
-    "client/std",
-    "rstd/std",
-    "runtime-io/std",
-    "support/std",
-    "balances/std",
-    "babe/std",
-    "babe-primitives/std",
-    "executive/std",
-    "indices/std",
-    "grandpa/std",
-    "primitives/std",
-    "sr-primitives/std",
-    "system/std",
-    "timestamp/std",
-    "sudo/std",
-    "version/std",
-    "serde",
     "safe-mix/std",
-    "offchain-primitives/std",
+    "serde",
+    "sr-primitives/std",
+    "sr-io/std",
+    "sr-std/std",
+    "sr-version/std",
+    "srml-babe/std",
+    "srml-balances/std",
+    "srml-executive/std",
+    "srml-grandpa/std",
+    "srml-indices/std",
+    "srml-sudo/std",
+    "srml-support/std",
+    "srml-system/std",
+    "srml-timestamp/std",
+    "substrate-client/std",
+    "substrate-consensus-babe-primitives/std",
+    "substrate-offchain-primitives/std",
+    "substrate-primitives/std",
     "substrate-session/std",
 ]
 
@@ -45,59 +45,49 @@ version = "1.0.101"
 default-features = false
 version = "1.0.0"
 
-[dependencies.babe]
+[dependencies.srml-babe]
 path = "../substrate/srml/babe"
-package = "srml-babe"
 default-features = false
 
-[dependencies.babe-primitives]
+[dependencies.substrate-consensus-babe-primitives]
 path = "../substrate/core/consensus/babe/primitives"
-package = "substrate-consensus-babe-primitives"
 default-features = false
 
-[dependencies.balances]
+[dependencies.srml-balances]
 path = "../substrate/srml/balances"
-package = "srml-balances"
 default_features = false
 
-[dependencies.client]
+[dependencies.substrate-client]
 path = "../substrate/core/client"
-package = "substrate-client"
 default_features = false
 
-[dependencies.executive]
+[dependencies.srml-executive]
 path = "../substrate/srml/executive"
 package = "srml-executive"
 default_features = false
 
-[dependencies.grandpa]
+[dependencies.srml-grandpa]
 path = "../substrate/srml/grandpa"
-package = "srml-grandpa"
 default-features = false
 
-[dependencies.indices]
+[dependencies.srml-indices]
 path = "../substrate/srml/indices"
 default_features = false
-package = "srml-indices"
 
-[dependencies.offchain-primitives]
+[dependencies.substrate-offchain-primitives]
 path = "../substrate/core/offchain/primitives"
-package = "substrate-offchain-primitives"
 default-features = false
 
-[dependencies.primitives]
+[dependencies.substrate-primitives]
 path = "../substrate/core/primitives"
 default_features = false
-package = "substrate-primitives"
 
-[dependencies.rstd]
+[dependencies.sr-std]
 path = "../substrate/core/sr-std"
-package = "sr-std"
 default_features = false
 
-[dependencies.runtime-io]
+[dependencies.sr-io]
 path = "../substrate/core/sr-io"
-package = "sr-io"
 default_features = false
 
 [dependencies.sr-primitives]
@@ -112,31 +102,26 @@ default_features = false
 path = "../substrate/core/session"
 default-features = false
 
-[dependencies.sudo]
+[dependencies.srml-sudo]
 path = "../substrate/srml/sudo"
 package = "srml-sudo"
 default_features = false
 
-[dependencies.support]
+[dependencies.srml-support]
 path = "../substrate/srml/support"
-package = "srml-support"
 default_features = false
 
-[dependencies.system]
+[dependencies.srml-system]
 path = "../substrate/srml/system"
-package = "srml-system"
 default_features = false
 
-[dependencies.timestamp]
+[dependencies.srml-timestamp]
 path = "../substrate/srml/timestamp"
-package = "srml-timestamp"
 default_features = false
 
-[dependencies.version]
+[dependencies.sr-version]
 path = "../substrate/core/sr-version"
-package = "sr-version"
 default_features = false
 
-[build-dependencies.wasm-builder-runner]
-package = "substrate-wasm-builder-runner"
+[build-dependencies.substrate-wasm-builder-runner]
 version = "1.0.2"

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,4 +1,4 @@
-use wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSource};
+use substrate_wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSource};
 
 const DUMMY_WASM_BINARY_ENV: &str = "BUILD_DUMMY_WASM_BINARY";
 

--- a/runtime/src/counter.rs
+++ b/runtime/src/counter.rs
@@ -6,15 +6,16 @@
 
 /// For more guidance on Substrate modules, see the example module
 /// https://github.com/paritytech/substrate/blob/master/srml/example/src/lib.rs
-use support::{decl_event, decl_module, decl_storage, dispatch::Result};
-use system::ensure_signed;
+use srml_support::{decl_event, decl_module, decl_storage, dispatch::Result};
+use srml_system as system;
+use srml_system::ensure_signed;
 
 /// The module's configuration trait.
-pub trait Trait: system::Trait {
+pub trait Trait: srml_system::Trait {
     // TODO: Add other types and constants required configure this module.
 
     /// The overarching event type.
-    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+    type Event: From<Event<Self>> + Into<<Self as srml_system::Trait>::Event>;
 }
 
 // This module's storage items.
@@ -51,7 +52,7 @@ decl_module! {
 decl_event!(
     pub enum Event<T>
     where
-        AccountId = <T as system::Trait>::AccountId,
+        AccountId = <T as srml_system::Trait>::AccountId,
     {
         Incremented(u32, AccountId),
     }


### PR DESCRIPTION
We normalize package names in runtime package: Instead of declaring
`srml_system` as `system` in `Cargo.toml` we use its actual name.