### PR TITLE
Do not use substrate git submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
 
     steps:
       - checkout
-      - run: git submodule update --init
       - run:
           name: "Setup shell environment"
           command: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "substrate"]
-	path = substrate
-	url = https://github.com/paritytech/substrate.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2619,18 +2620,18 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radicle_registry_runtime 0.1.0",
- "sr-io 2.0.0",
- "substrate-basic-authorship 2.0.0",
- "substrate-cli 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-aura 2.0.0",
- "substrate-consensus-aura-primitives 2.0.0",
- "substrate-executor 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-network 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-service 2.0.0",
- "substrate-transaction-pool 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2641,24 +2642,24 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "sr-version 2.0.0",
- "srml-aura 2.0.0",
- "srml-balances 2.0.0",
- "srml-executive 2.0.0",
- "srml-indices 2.0.0",
- "srml-randomness-collective-flip 2.0.0",
- "srml-sudo 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "srml-timestamp 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-aura-primitives 2.0.0",
- "substrate-offchain-primitives 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-session 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-balances 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-executive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-indices 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-sudo 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3251,6 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api-macros"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3262,22 +3264,24 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
- "substrate-externalities 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-state-machine 2.0.0",
- "substrate-trie 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3287,24 +3291,26 @@ dependencies = [
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-std 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "sr-staking-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "sr-std"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3312,130 +3318,140 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-aura"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-session 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "srml-timestamp 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-consensus-aura-primitives 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-balances"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "substrate-keyring 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-executive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-indices"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "substrate-keyring 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-metadata"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-randomness-collective-flip"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-session"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-staking-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "srml-timestamp 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-sudo"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-support"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3443,40 +3459,43 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-metadata 2.0.0",
- "srml-support-procedural 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-support-procedural"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 2.0.0",
- "srml-support-procedural-tools 2.0.0",
+ "sr-api-macros 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 2.0.0",
+ "srml-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3486,31 +3505,33 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "sr-version 2.0.0",
- "srml-support 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "srml-timestamp"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "substrate-inherents 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
@@ -3589,17 +3610,19 @@ dependencies = [
 [[package]]
 name = "substrate-application-crypto"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-std 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-authority-discovery"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3610,38 +3633,40 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-authority-discovery-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-network 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-authority-discovery-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-authority-discovery-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "substrate-client 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-basic-authorship"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-telemetry 2.0.0",
- "substrate-transaction-pool 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
@@ -3658,20 +3683,22 @@ dependencies = [
 [[package]]
 name = "substrate-chain-spec"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-trait-for-tuples 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-chain-spec-derive 2.0.0",
- "substrate-network 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-telemetry 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-chain-spec-derive"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3682,6 +3709,7 @@ dependencies = [
 [[package]]
 name = "substrate-cli"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3699,17 +3727,17 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-client 2.0.0",
- "substrate-header-metadata 2.0.0",
- "substrate-keyring 2.0.0",
- "substrate-network 2.0.0",
- "substrate-panic-handler 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-service 2.0.0",
- "substrate-state-machine 2.0.0",
- "substrate-telemetry 2.0.0",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-service 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3717,6 +3745,7 @@ dependencies = [
 [[package]]
 name = "substrate-client"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3728,24 +3757,25 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 2.0.0",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "sr-version 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-executor 2.0.0",
- "substrate-header-metadata 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-keyring 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-state-machine 2.0.0",
- "substrate-telemetry 2.0.0",
- "substrate-trie 2.0.0",
+ "sr-api-macros 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-client-db"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -3755,20 +3785,21 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-executor 2.0.0",
- "substrate-header-metadata 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-state-db 2.0.0",
- "substrate-state-machine 2.0.0",
- "substrate-trie 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-consensus-aura"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3777,49 +3808,52 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "sr-version 2.0.0",
- "srml-aura 2.0.0",
- "srml-support 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-aura-primitives 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-consensus-slots 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-keystore 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-telemetry 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-client 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-slots 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3828,33 +3862,35 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "sr-version 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-consensus-slots"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-telemetry 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-executor"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3863,14 +3899,14 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-version 2.0.0",
- "substrate-externalities 2.0.0",
- "substrate-panic-handler 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-serializer 2.0.0",
- "substrate-trie 2.0.0",
- "substrate-wasm-interface 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3878,60 +3914,66 @@ dependencies = [
 [[package]]
 name = "substrate-externalities"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
- "substrate-primitives-storage 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-header-metadata"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-inherents"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-keyring"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-keystore"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-application-crypto 2.0.0",
- "substrate-primitives 2.0.0",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-network"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3939,7 +3981,7 @@ dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 2.0.0",
+ "fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3957,13 +3999,13 @@ dependencies = [
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-consensus-babe-primitives 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-header-metadata 2.0.0",
- "substrate-peerset 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3973,6 +4015,7 @@ dependencies = [
 [[package]]
 name = "substrate-offchain"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3985,26 +4028,28 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-keystore 2.0.0",
- "substrate-network 2.0.0",
- "substrate-offchain-primitives 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-transaction-pool 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-offchain-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4013,6 +4058,7 @@ dependencies = [
 [[package]]
 name = "substrate-peerset"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4025,6 +4071,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4046,10 +4093,10 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-externalities 2.0.0",
- "substrate-primitives-storage 2.0.0",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4059,15 +4106,17 @@ dependencies = [
 [[package]]
 name = "substrate-primitives-storage"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "impl-serde 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-rpc"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4077,22 +4126,23 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-version 2.0.0",
- "substrate-client 2.0.0",
- "substrate-executor 2.0.0",
- "substrate-keystore 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-rpc-api 2.0.0",
- "substrate-rpc-primitives 2.0.0",
- "substrate-session 2.0.0",
- "substrate-state-machine 2.0.0",
- "substrate-transaction-pool 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-rpc-api"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4105,23 +4155,25 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-version 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-rpc-primitives 2.0.0",
- "substrate-transaction-graph 2.0.0",
+ "sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-rpc-primitives"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-rpc-servers"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4130,12 +4182,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-serializer"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4144,6 +4197,7 @@ dependencies = [
 [[package]]
 name = "substrate-service"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4157,25 +4211,25 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
- "sr-primitives 2.0.0",
- "substrate-application-crypto 2.0.0",
- "substrate-authority-discovery 2.0.0",
- "substrate-authority-discovery-primitives 2.0.0",
- "substrate-chain-spec 2.0.0",
- "substrate-client 2.0.0",
- "substrate-client-db 2.0.0",
- "substrate-consensus-common 2.0.0",
- "substrate-executor 2.0.0",
- "substrate-keystore 2.0.0",
- "substrate-network 2.0.0",
- "substrate-offchain 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-rpc 2.0.0",
- "substrate-rpc-servers 2.0.0",
- "substrate-session 2.0.0",
- "substrate-telemetry 2.0.0",
- "substrate-transaction-pool 2.0.0",
+ "sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-authority-discovery-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "sysinfo 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4185,26 +4239,29 @@ dependencies = [
 [[package]]
 name = "substrate-session"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "substrate-client 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-state-db"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 2.0.0",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-state-machine"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4212,10 +4269,10 @@ dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-externalities 2.0.0",
- "substrate-panic-handler 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-trie 2.0.0",
+ "substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4223,6 +4280,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4244,40 +4302,43 @@ dependencies = [
 [[package]]
 name = "substrate-transaction-graph"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-transaction-pool"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
- "substrate-primitives 2.0.0",
- "substrate-transaction-graph 2.0.0",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
 ]
 
 [[package]]
 name = "substrate-trie"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 2.0.0",
- "substrate-primitives 2.0.0",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
+ "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)",
  "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4290,6 +4351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-wasm-interface"
 version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c#9b8bfd72126be453cda302caff28a6c99adee14c"
 dependencies = [
  "wasmi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5197,6 +5259,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fork-tree 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
 "checksum fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -5441,6 +5504,26 @@ dependencies = [
 "checksum soketto 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bceb1a3a15232d013d9a3b7cac9e5ce8e2313f348f01d4bc1097e5e53aa07095"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+"checksum sr-api-macros 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum sr-io 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum sr-staking-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum sr-std 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum sr-version 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-balances 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-executive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-indices 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-sudo 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-support 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-support-procedural 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-support-procedural-tools 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-support-procedural-tools-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-system 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum srml-timestamp 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "92a7e0c5e3dfb52e8fbe0e63a1b947bbb17b4036408b151353c4491374931362"
@@ -5451,8 +5534,49 @@ dependencies = [
 "checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
+"checksum substrate-application-crypto 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-authority-discovery 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-authority-discovery-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-basic-authorship 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
+"checksum substrate-chain-spec 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-chain-spec-derive 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-cli 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-client 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-client-db 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-consensus-aura 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-consensus-aura-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-consensus-common 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-consensus-slots 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-executor 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-externalities 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-keystore 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-network 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-offchain 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-panic-handler 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-peerset 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-primitives-storage 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-rpc 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-rpc-api 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-rpc-primitives 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-rpc-servers 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-serializer 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-service 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-session 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-state-db 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-state-machine 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-telemetry 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-transaction-graph 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-transaction-pool 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
+"checksum substrate-trie 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
 "checksum substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af21b27fad38b212c1919f700cb0def33c88cde14d22e0d1b17d4521f4eb8b40"
+"checksum substrate-wasm-interface 2.0.0 (git+https://github.com/paritytech/substrate?rev=9b8bfd72126be453cda302caff28a6c99adee14c)" = "<none>"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -23,6 +23,17 @@ Packages
   lives on chain.
 * `node` contains the node code which includes the runtime code.
 
+
+Updating substrate
+------------------
+
+To update the revision of substrate run
+~~~
+./scripts/update-substrate REV
+~~~
+where `REV` is the new Git revision SHA.
+
+
 Updating Continuous Integration's base Docker image
 ---------------------------------------------------
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,44 +25,56 @@ version = "3.1.3"
 path = "../runtime"
 
 [dependencies.aura]
-path = "../substrate/core/consensus/aura"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-consensus-aura"
 
 [dependencies.aura-primitives]
-path = "../substrate/core/consensus/aura/primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-consensus-aura-primitives"
 
 [dependencies.basic-authorship]
-path = "../substrate/core/basic-authorship"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-basic-authorship"
 
 [dependencies.inherents]
-path = "../substrate/core/inherents"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-inherents"
 
 [dependencies.network]
-path = "../substrate/core/network"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-network"
 
 [dependencies.primitives]
-path = "../substrate/core/primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-primitives"
 
 [dependencies.sr-io]
-path = "../substrate/core/sr-io"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 
 [dependencies.substrate-cli]
-path = "../substrate/core/cli"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 
 [dependencies.substrate-client]
-path = "../substrate/core/client"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 
 [dependencies.substrate-executor]
-path = "../substrate/core/executor"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 
 [dependencies.substrate-service]
-path = "../substrate/core/service"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 
 [dependencies.transaction-pool]
-path = "../substrate/core/transaction-pool"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "substrate-transaction-pool"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -40,77 +40,95 @@ optional = true
 version = "1.0.101"
 
 [dependencies.srml-aura]
-path = "../substrate/srml/aura"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default-features = false
 
 [dependencies.substrate-consensus-aura-primitives]
-path = "../substrate/core/consensus/aura/primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default-features = false
 
 [dependencies.srml-balances]
-path = "../substrate/srml/balances"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.substrate-client]
-path = "../substrate/core/client"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.srml-executive]
-path = "../substrate/srml/executive"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "srml-executive"
 default_features = false
 
 [dependencies.srml-indices]
-path = "../substrate/srml/indices"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.substrate-offchain-primitives]
-path = "../substrate/core/offchain/primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default-features = false
 
 [dependencies.substrate-primitives]
-path = "../substrate/core/primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.sr-std]
-path = "../substrate/core/sr-std"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.sr-io]
-path = "../substrate/core/sr-io"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.sr-primitives]
-path = "../substrate/core/sr-primitives"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.srml-randomness-collective-flip]
-path = "../substrate/srml/randomness-collective-flip"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.substrate-session]
-path = "../substrate/core/session"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default-features = false
 
 [dependencies.srml-sudo]
-path = "../substrate/srml/sudo"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 package = "srml-sudo"
 default_features = false
 
 [dependencies.srml-support]
-path = "../substrate/srml/support"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.srml-system]
-path = "../substrate/srml/system"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.srml-timestamp]
-path = "../substrate/srml/timestamp"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [dependencies.sr-version]
-path = "../substrate/core/sr-version"
+git = "https://github.com/paritytech/substrate"
+rev = "9b8bfd72126be453cda302caff28a6c99adee14c"
 default_features = false
 
 [build-dependencies.substrate-wasm-builder-runner]

--- a/scripts/update-substrate
+++ b/scripts/update-substrate
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  echo "Revision argument is missing"
+  echo "Usage: $0 <revision>"
+  exit 1
+fi
+
+if [[ ! "${1}" =~ ^[0-9a-f]{40,40}$ ]]; then
+  echo "Invalid revision format"
+  exit 1
+fi
+
+# Reads `Cargo.lock` and extracts the first revision of the `substrate`
+# repo that is used.
+function get_substrate_rev () {
+  while read LINE; do
+    if [[ "$LINE" =~ ^\"checksum\ .*git\+https://github\.com/paritytech/substrate.*\?rev=([0-9a-f]{40,40}) ]]; then
+      echo ${BASH_REMATCH[1]}
+      return
+    fi
+  done < Cargo.lock
+  return 1
+}
+
+substrate_rev=$(get_substrate_rev)
+
+sed -i s/${substrate_rev}/$1/g */Cargo.toml


### PR DESCRIPTION
Using a Git submodule for the substrate dependency generates more problems than it solves. We switch back to a git dependency but provide tooling to update substrate properly.