### PR TITLE
Make CI base image smaller and add 'make' dependency

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,7 +2,7 @@ steps:
   - label: "Check formatting, lint, build and test "
     command: 'ci/run'
     env:
-      DOCKER_IMAGE: gcr.io/opensourcecoin/radicle-registry@sha256:264a6e976faeb63adda312cd3ecf2fb9ff71fd6f030128b3f012daf9c4cff05b
+      DOCKER_IMAGE: gcr.io/opensourcecoin/radicle-registry@sha256:380b136cc99473571edcc5618701975bb59d6c0f4d1c520ce520385cffd051b1
       DOCKER_FILE: ci/base-image/Dockerfile
     agents:
       platform: "linux"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -42,9 +42,13 @@ After performing the necessary changes to the Dockerfile located in
 repository and run the following:
 
 ```bash
-docker build ci/base-image --tag gcr.io/opensourcecoin/radicle-registry;
+docker build ci/base-image --tag gcr.io/opensourcecoin/radicle-registry
 docker push gcr.io/opensourcecoin/radicle-registry
 ```
+
+The `docker push` command outputs the pushed image’s digest. To use the pushed
+image in Buildkite runs, update the `DOCKER_IMAGE` value in
+`.buildkite/pipeline.yaml` with the new digest.
 
 Note that an account with permission to push to the Google Cloud Registry
 address at `gcr.io/opensourcecoin/radicle-registry` is required in order for
@@ -57,28 +61,3 @@ https://cloud.google.com/container-registry/docs/access-control.
 
 If all this fails, request assistance to someone that can grant these
 permissions.
-
-Updating the Buildkite pipeline
--------------------------------
-
-After this is done, the Buildkite pipeline located at `.buildkite/pipeline.yml`
-will also need to be updated with the correct Docker image digest -
-specifically, the `DOCKER_IMAGE` environment variable.
-
-
-To find the digest for the image build from the above steps, run
-
-```bash
-docker images --digests | grep radicle-registry
-```
-
-which should produce output like
-
-```
-gcr.io/opensourcecoin/radicle-registry       latest                                     sha256:264a6e976faeb63adda312cd3ecf2fb9ff71fd6f030128b3f012daf9c4cff05b   c824ae208aff        50 minutes ago      3.15GB
-gcr.io/opensourcecoin/radicle-registry       <none>                                     sha256:41347023e88ff45254a95bcf09cb3085e0d6bc677eda45e8de2a4611191eb2fe   7f985cd4d719        3 days ago          3.23GB
-```
-
-The new image digest in this case will be
-sha256:264a6e976faeb63adda312cd3ecf2fb9ff71fd6f030128b3f012daf9c4cff05b, as it
-is the most recently built.

--- a/ci/base-image/Dockerfile
+++ b/ci/base-image/Dockerfile
@@ -1,36 +1,76 @@
-FROM rust:1.38.0-slim-buster
+# Image to run builds of the project
+#
+# Includes
+#
+# * Rustup with `nightly-2019-09-05` toolchain (see RUST_VERSION)
+# * Additional rustup components and the wasm32 target
+# * wasm-gc
+# * sccache v0.2.12
 
-# Install additional packages
+FROM debian:buster-slim
+
+SHELL ["/bin/bash", "-c"]
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=nightly-2019-09-05 \
+    SCCACHE_DIR=/cache/sccache \
+    RUSTC_WRAPPER=sccache \
+    CARGO_HOME=/usr/local/cargo
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        cmake \
-        libclang-dev \
-        llvm-dev \
+        ca-certificates \
         clang \
-        g++ \
+        cmake \
+        gcc \
+        libclang-dev \
         libssl-dev \
+        llvm-dev \
+        make \
         pkg-config \
-        curl \
+        wget \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSLO https://github.com/mozilla/sccache/releases/download/0.2.12/sccache-0.2.12-x86_64-unknown-linux-musl.tar.gz \
-    && echo "26fd04c1273952cc2a0f359a71c8a1857137f0ee3634058b3f4a63b69fc8eb7f  sccache-0.2.12-x86_64-unknown-linux-musl.tar.gz" > sccache.sum \
-    && sha256sum -c sccache.sum \
-    && tar -zxf sccache-0.2.12-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-0.2.12-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache \
-    && rm -rf sccache-0.2.12-x86_64-unknown-linux-musl
+# Install sccache
+RUN set -euxo pipefail; \
+    sccache_version=0.2.12; \
+    sccache_base=sccache-$sccache_version-x86_64-unknown-linux-musl; \
+    wget --quiet https://github.com/mozilla/sccache/releases/download/$sccache_version/$sccache_base.tar.gz; \
+    echo "26fd04c1273952cc2a0f359a71c8a1857137f0ee3634058b3f4a63b69fc8eb7f  $sccache_base.tar.gz" | sha256sum -c -; \
+    tar -zxf "$sccache_base.tar.gz"; \
+    mv "$sccache_base/sccache" /usr/local/bin/sccache; \
+    rm -r "$sccache_base.tar.gz" "$sccache_base"
 
-# Use correct toolchain, install WASM components required by the ledger, and
-# Rust utilities necessary in some CI pipeline steps i.e. formatting check,
-# linting.
-RUN rustup default nightly-2019-09-05 \
-    && rustup update \
-    && rustup component add rustfmt \
+# Install rustup and default toolchain from RUST_VERSION. This is copied from
+# https://github.com/rust-lang/docker-rust/blob/1d8ef2981548b4b54767e09274c26b2dd6a4e9ec/1.38.0/buster/slim/Dockerfile
+RUN set -euxo pipefail; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='36285482ae5c255f2decfab27d32ba19465804cb3ddf5a23e6ff2a7b0f6e0250' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='cb20e54566d4b13434dea1776a961cf7f97afcc292cb4b0fec533503dd2434d0' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='58e19ae12101103ccc50b04a2579b9238163f87a27da5078cefc900098f257ab' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='d3c42fb8b25f87eb049b6177611eea7d4fd51273de4113706f43cccf5610cfc7' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.19.0/${rustArch}/rustup-init"; \
+    wget --quiet "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Add components to toolchain install wasm-gc
+RUN rustup component add rustfmt \
     && rustup component add clippy \
     && rustup target add wasm32-unknown-unknown \
     && cargo install --git https://github.com/alexcrichton/wasm-gc
 
-# Setup defaults for caching
 VOLUME /cache
-ENV SCCACHE_DIR=/cache/sccache RUSTC_WRAPPER=sccache CARGO_HOME=/cache/cargo
+ENV CARGO_HOME=/cache/cargo


### PR DESCRIPTION
* We make the CI base image smaller by not basing it on `rust:1.38.0` which includes the whole 1.38.0 toolchain but installing Rust from scratch. For this we copy the code from the `rust` dockerfiles. This reduces the image size from 3.15GB to 2.03GB.
* We add `make` to the list of dependencies. This is required by some new rust dependencies of the client.
* We simplify the documentation by pointing out that the digest is printed by `docker push`.