### PR TITLE
Raise error when chain spec is unknown

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -69,7 +69,10 @@ fn load_spec(id: &str) -> Result<Option<chain_spec::ChainSpec>, String> {
     if id == "dev" {
         Ok(Some(chain_spec::dev()))
     } else {
-        Ok(None)
+        Err(format!(
+            "Unknown chain spec \"{}\". You must run the node with --dev",
+            id
+        ))
     }
 }
 


### PR DESCRIPTION
Show a more informative error to the user when the node is not run with `--dev`. Before it just complained about a random file missing.