### PR TITLE
Eliminate srml-indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,7 +3142,6 @@ dependencies = [
  "srml-aura",
  "srml-balances",
  "srml-executive",
- "srml-indices",
  "srml-randomness-collective-flip",
  "srml-sudo",
  "srml-support",

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,7 +6,7 @@
 //! runtime.
 use futures01::prelude::*;
 
-use radicle_registry_runtime::{balances, counter, registry, Address};
+use radicle_registry_runtime::{balances, counter, registry};
 use substrate_subxt::balances::BalancesStore;
 
 mod base;
@@ -58,7 +58,7 @@ impl Client {
         self.base_client
             .submit_and_watch_call(
                 key_pair,
-                balances::Call::transfer(Address::Id(receiver.clone()), balance),
+                balances::Call::transfer(receiver.clone(), balance),
             )
             .map(|_| ())
     }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,8 +1,7 @@
 use aura_primitives::sr25519::AuthorityId as AuraId;
 use primitives::{Pair, Public};
 use radicle_registry_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, IndicesConfig, SudoConfig, SystemConfig,
-    WASM_BINARY,
+    AccountId, AuraConfig, BalancesConfig, GenesisConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -41,9 +40,6 @@ fn dev_genesis_config() -> GenesisConfig {
         system: Some(SystemConfig {
             code: WASM_BINARY.to_vec(),
             changes_trie_config: Default::default(),
-        }),
-        srml_indices: Some(IndicesConfig {
-            ids: endowed_accounts.clone(),
         }),
         srml_balances: Some(BalancesConfig {
             balances: endowed_accounts

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,6 @@ std = [
     "srml-aura/std",
     "srml-balances/std",
     "srml-executive/std",
-    "srml-indices/std",
     "srml-sudo/std",
     "srml-support/std",
     "srml-system/std",
@@ -64,11 +63,6 @@ default_features = false
 git = "https://github.com/paritytech/substrate"
 rev = "acf86cd4b0ad4c45dbba57c2ae323531d5b71264"
 package = "srml-executive"
-default_features = false
-
-[dependencies.srml-indices]
-git = "https://github.com/paritytech/substrate"
-rev = "acf86cd4b0ad4c45dbba57c2ae323531d5b71264"
 default_features = false
 
 [dependencies.substrate-offchain-primitives]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,7 +124,7 @@ impl srml_system::Trait for Runtime {
     /// The aggregated dispatch type that is available for extrinsics.
     type Call = Call;
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-    type Lookup = Indices;
+    type Lookup = sr_primitives::traits::IdentityLookup<AccountId>;
     /// The index type for storing how many extrinsics an account has signed.
     type Index = Index;
     /// The index type for blocks.
@@ -152,18 +152,6 @@ impl srml_system::Trait for Runtime {
 
 impl srml_aura::Trait for Runtime {
     type AuthorityId = AuraId;
-}
-
-impl srml_indices::Trait for Runtime {
-    /// The type for recording indexing into the account enumeration. If this ever overflows, there
-    /// will be problems!
-    type AccountIndex = AccountIndex;
-    /// Use the standard means of resolving an index hint from an id.
-    type ResolveHint = srml_indices::SimpleResolveHint<Self::AccountId, Self::AccountIndex>;
-    /// Determine whether an account is dead.
-    type IsDeadAccount = Balances;
-    /// The ubiquitous event type.
-    type Event = Event;
 }
 
 parameter_types! {
@@ -201,7 +189,7 @@ impl srml_balances::Trait for Runtime {
     /// What to do if an account's free balance gets zeroed.
     type OnFreeBalanceZero = ();
     /// What to do if a new account is created.
-    type OnNewAccount = Indices;
+    type OnNewAccount = ();
     /// The ubiquitous event type.
     type Event = Event;
     type DustRemoval = ();
@@ -236,7 +224,6 @@ construct_runtime!(
                 Timestamp: srml_timestamp::{Module, Call, Storage, Inherent},
                 RandomnessCollectiveFlip: srml_randomness_collective_flip::{Module, Storage},
                 Aura: srml_aura::{Module, Config<T>, Inherent(Timestamp)},
-                Indices: srml_indices::{default, Config<T>},
                 Balances: srml_balances::{default, Error},
                 Sudo: srml_sudo,
                 Counter: counter::{Module, Call, Storage, Event<T>},
@@ -244,8 +231,6 @@ construct_runtime!(
         }
 );
 
-/// The address format for describing accounts.
-pub type Address = srml_indices::Address<Runtime>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -264,7 +249,7 @@ pub type SignedExtra = (
     srml_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<AccountId, Call, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
 /// Executive: handles dispatch to the various modules.


### PR DESCRIPTION
We remove the `srml-indices` module from our runtime. We only used it for short addresses but we don’t need this.