### PR TITLE
spec: Adjust type names and docs for more clarity

### DIFF
--- a/registry-spec/src/lib.rs
+++ b/registry-spec/src/lib.rs
@@ -25,8 +25,7 @@ pub trait RegistryTransactions {
         from_acc: types::AccountId,
         // Account to which Oscoin will be sent.
         to_acc: types::AccountId,
-        // Amount of Oscoin to be sent.
-        amount: types::Oscoin,
+        amount: types::Balance,
     ) -> Result<types::TxHash, error::TransferError>;
 
     /// Registers a project on the Oscoin Registry and returns the new project’s ID.
@@ -43,15 +42,12 @@ pub trait RegistryTransactions {
     /// project is later accepted or rejected, the registration fee is deducted
     /// from the transaction sender's account - if no such available balance is
     /// found, it will result in an error.
-    ///
-    /// Preconditions:
-    /// * The ownership proof can only be up to 4096 bytes long.
     fn register_project(
         // Requested name of the project to be registered.
         project_id: types::ProjectId,
         project_checkpoint: types::CheckpointId,
         project_contract: types::Contract,
-        project_ownership_proof: types::Proof,
+        project_ownership_proof: types::ProjectOwnershipProof,
         project_meta: types::Meta,
     ) -> Result<types::TxHash, error::RegisterProjectError>;
 
@@ -102,7 +98,7 @@ pub trait RegistryTransactions {
         new_project_version: types::Version,
         // Hash-linked list of the checkpoint's contributions. To see more
         // about this type, go to types::Contribution.
-        contribution_list: types::HashLinkedList<types::Contribution>,
+        contribution_list: types::ContributionList,
         // A vector of dependency updates. See types::DependencyUpdate
         // for more information.
         //
@@ -116,7 +112,7 @@ pub trait RegistryView {
     /// Returns the project registered at the given address.
     ///
     /// Returns `None` if no project was registered or the project was unregistered.
-    fn get_project(project_address: types::AccountId) -> Option<types::Project>;
+    fn get_project(project_address: types::ProjectId) -> Option<types::Project>;
 
     /// Returns the [Account] at the given address.
     ///

--- a/registry-spec/src/types.rs
+++ b/registry-spec/src/types.rs
@@ -1,7 +1,4 @@
-use std::marker::PhantomData;
-
 pub struct Account {
-    /// Hash of the account owner's public key.
     pub id: AccountId,
 
     /// Transaction counter that is increased whenever a transaction is sent from this account.
@@ -9,26 +6,22 @@ pub struct Account {
     /// A transaction is only valid if its nonce matches the nonce of its sender account when the
     /// transaction is applied.
     pub nonce: u64,
-    pub balance: Oscoin,
+    pub balance: Balance,
 }
 
-/// Type for human-readable registry addresses. Its specific data structure is
-/// not important here.
-pub struct Address;
-
-/// Type for account identifier. Uniquely corresponds to an account in the
-/// registry.
+/// Identifier for an account.
 ///
-/// At present it is assumed to be the same as `Address`, but will eventually
-/// diverge.
-pub type AccountId = Address;
+/// An `AccountId` is the same as the public key of that is used to verify transactions originating
+/// from an account.
+pub struct AccountId;
 
-/// Type for Registry public keys. Its specific data structure is not
-/// important here, just as it is with `Address`es.
-pub struct PublicKey;
+/// A public key that is understood by GPG.
+///
+/// This is used for verifying project contributions that are signed with GPG keys.
+pub struct GpgPublicKey;
 
 /// Type representing a GPG signature of data.
-pub struct Signature;
+pub struct GpgSignature;
 
 /// Type for the hash digest used in the Oscoin Registry. Useful to represent
 /// commit hashes or public keys.
@@ -37,13 +30,11 @@ pub struct Hash;
 /// The hash of a transaction. Uniquely identifies a transaction.
 pub struct TxHash;
 
-/// Numerical type representing Oscoin amounts. It is still to be decided, but
-/// it may be `u64`, `u128` or even a rational type so fractional amounts can
-/// be represented. Subject to discussion.
-pub struct Oscoin;
-
-/// Representation of a contribution's author.
-pub type Author = PublicKey;
+/// Token balance associated with an account.
+///
+/// The balance is always positive. It is still to be decided, but it may be `u64`, `u128` or even
+/// a rational type so fractional amounts can be represented. Subject to discussion.
+pub struct Balance;
 
 /// ID of a project's current checkpoint.
 pub struct CheckpointId;
@@ -62,7 +53,7 @@ pub type ProjectId = (ProjectName, ProjectDomain);
 /// A structure that contains a proof that the entity that submitted the
 /// `register_project` transaction actually has ownership of the submitted
 /// `Project`.
-pub type Proof = Vec<u8>;
+pub struct ProjectOwnershipProof;
 
 /// A structure that contains a dictionary of metadata to associate with a
 /// project. for example the Radicle id that project uses on that service.
@@ -71,12 +62,11 @@ pub struct Meta;
 
 /// Representation of a project in the Oscoin registry.
 pub struct Project {
-    pub addr: ProjectId,
-    /// The project's latest checkpoint's ID.
-    pub hash: CheckpointId,
     pub id: ProjectId,
+    /// The project's latest checkpoint's ID.
+    pub checkpoint: CheckpointId,
     pub contract: Contract,
-    pub proof: Proof,
+    pub proof: ProjectOwnershipProof,
     pub meta: Meta,
 }
 
@@ -86,34 +76,22 @@ pub struct Contract;
 /// A project's version at a given point in time.
 pub type Version = String;
 
-/// Datatype representing a hash-linked-list. Used to organize contributions
-/// when checkpointing.
+/// Hash linked list of [Contribution]s.
 ///
-/// The type it abstracts over - with contributions here abbreviated as `C` -
-/// should be a tuple, struct or equivalent with at least two fields e.g.
-/// `prev` and `commit` such that for every two consecutive members of the
-/// hash-linked-list `C {prev1 = hash1, commit1 = hash2 .. }, C {prev2 = hash3, commit2 = hash4 ..}`:
-/// * it is true that `hash2 == hash3`;
-/// * if `hash1` is the first hash present in the list, it is either
-///   * the same as the last hash present in the last contribution of the last
-///     checkpoint, or
-///   * an empty hash, in case this is a project's first checkpoint.
-///
-/// In practice, it may not necessarily be a list, but conceptually the name
-/// is explanatory.
-pub struct HashLinkedList<T> {
-    contributions: PhantomData<T>,
-}
+/// A [ContributionList] `cs` is valid if for every item `c` excluding the first item `c.parent`
+/// equals `Some(d.hash)` where `d` is the previous item in the list.
+pub struct ContributionList(Vec<Contribution>);
 
 /// Datatype representing a contribution, one of the data required by a
 /// checkpoint.
+///
+/// A contribution is valid if [sig] is a valid signature of [hash] for the public key [author].
 pub struct Contribution {
-    pub parent: Hash,
     pub hash: Hash,
-    // Note that `author` must be the public key that signed the contribution
-    // a data structure of this type must refer to.
-    pub author: Author,
-    pub sig: Signature,
+    /// Hash of the previous contribution’s [hash] or `None` if thi is the firt contribution.
+    pub parent: Option<Hash>,
+    pub author: GpgPublicKey,
+    pub sig: GpgSignature,
 }
 
 /// Datatype representing a dependency update, another segment of data required

--- a/registry-spec/src/types.rs
+++ b/registry-spec/src/types.rs
@@ -88,7 +88,7 @@ pub struct ContributionList(Vec<Contribution>);
 /// A contribution is valid if [sig] is a valid signature of [hash] for the public key [author].
 pub struct Contribution {
     pub hash: Hash,
-    /// Hash of the previous contribution’s [hash] or `None` if thi is the firt contribution.
+    /// Hash of the previous contribution’s [hash] or `None` if this is the first contribution.
     pub parent: Option<Hash>,
     pub author: GpgPublicKey,
     pub sig: GpgSignature,


### PR DESCRIPTION
* Rename `Oscoin` to `Balance`. The name of the currency is going to be `Rad` but we should focus on descriptive names and not own names.
* Rename `Proof` to `ProjectOwnershipProof` and make it opaque. It is not a general purpose proof and we don’t know yet what it’s structure is.
* Make `AccountId` opaque and update the documentation so that it becomes clear that it is a public key. Also remove `Address` which was only used to alias to `AccountId`.
* Prefix `PublicKey` and `Signature` with `Gpg`. This distinguishes GPG crypto used for contribution claiming from the rest of the registry crypto.
* Replace generic `HashLinkedList` with `ContributionList`. No need to abstract in the spec, especially if it is only used once. This also makes it easier to document.