### PR TITLE
Fix error type associated with Client trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,6 +2955,7 @@ dependencies = [
  "sr-primitives",
  "srml-support",
  "substrate-primitives",
+ "substrate-subxt",
 ]
 
 [[package]]

--- a/client-interface/Cargo.toml
+++ b/client-interface/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 radicle_registry_runtime = { path = "../runtime" }
+substrate-subxt = { path = "../subxt" }
 
 futures = "0.1"
 

--- a/client-interface/src/lib.rs
+++ b/client-interface/src/lib.rs
@@ -22,34 +22,30 @@ pub struct RegisterProjectParams {
     pub img_url: String,
 }
 
+#[doc(inline)]
+pub type Error = substrate_subxt::Error;
+
 /// Return type for all [Client] methods.
 pub type Response<T, Error> = Box<dyn Future<Item = T, Error = Error> + Send>;
 
 /// Trait for ledger clients sending transactions and looking up state.
-///
-/// All methods return `Response<T, Client::Error>` where.
 pub trait Client {
-    /// Common errors for all methods.
-    ///
-    /// In implementations these might be connection errors, decoding errors, etc.
-    type Error;
-
     fn transfer(
         &self,
         key_pair: &ed25519::Pair,
         receiver: &AccountId,
         balance: Balance,
-    ) -> Response<(), Self::Error>;
+    ) -> Response<(), Error>;
 
-    fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Self::Error>;
+    fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error>;
 
     fn register_project(
         &self,
         author: &ed25519::Pair,
         project_params: RegisterProjectParams,
-    ) -> Response<ProjectId, Self::Error>;
+    ) -> Response<ProjectId, Error>;
 
-    fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Self::Error>;
+    fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Error>;
 
-    fn list_projects(&self) -> Response<Vec<ProjectId>, Self::Error>;
+    fn list_projects(&self) -> Response<Vec<ProjectId>, Error>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -49,8 +49,6 @@ impl Client {
 }
 
 impl ClientT for Client {
-    type Error = Error;
-
     fn transfer(
         &self,
         key_pair: &ed25519::Pair,


### PR DESCRIPTION
Instead of having an associated type on the `Client` trait we always use the `Error` from `subxt`. This makes it possible to use the client trait generically for both the node client and the memory client without doing error conversion.

We also changed the error handling behavior of the `MemoryClient`. Instead of passing errors from the runtime functions we expect them to be ok and panic otherwise.