### PR TITLE
Extract transaction signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,6 +2936,7 @@ dependencies = [
  "futures-preview",
  "log 0.4.8",
  "parity-scale-codec",
+ "radicle_registry_client_common",
  "radicle_registry_client_interface",
  "radicle_registry_runtime",
  "srml-support",
@@ -2946,14 +2947,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "radicle_registry_client_common"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "radicle_registry_runtime",
+ "sr-io",
+ "sr-primitives",
+ "srml-system",
+ "srml-transaction-payment",
+ "substrate-primitives",
+]
+
+[[package]]
 name = "radicle_registry_client_interface"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "parity-scale-codec",
  "radicle_registry_runtime",
  "sr-io",
  "sr-primitives",
  "srml-support",
+ "srml-system",
+ "srml-transaction-payment",
  "substrate-primitives",
  "substrate-subxt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 members = [
   "cli",
   "client",
+  "client-common",
   "client-interface",
   "memory-client",
   "node",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -24,6 +24,7 @@ Packages
 * `node` contains the node code which includes the runtime code.
 * `client` contains the high-level client library for interacting with the
   registry through a node.
+* `client-common` provides code that is used by the node client and the memory
 * `client-interface` defines the trait for clients and provides the necessary
   data types.
 * `memory-client` contains a implementation of the Client interface that uses an
@@ -38,7 +39,10 @@ Testing
 -------
 
 Black-box tests for the runtime logic are implemented with the `MemoryClient` in
-`runtime/tests/main`.
+`runtime/tests/main.rs`.
+
+End-to-end tests that run against a real node are implemented in
+`client/tests/end_to_end.rs`
 
 
 Upstream `subxt`

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name = "radicle_registry_client_interface"
+name = "radicle_registry_client_common"
 version = "0.1.0"
 authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
 
 [dependencies]
 radicle_registry_runtime = { path = "../runtime" }
-substrate-subxt = { path = "../subxt" }
 
 parity-scale-codec = "1.0"
-futures = "0.1"
 
 [dependencies.srml-system]
 git = "https://github.com/paritytech/substrate"
@@ -24,10 +22,6 @@ git = "https://github.com/paritytech/substrate"
 rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 
 [dependencies.sr-primitives]
-git = "https://github.com/paritytech/substrate"
-rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
-
-[dependencies.srml-support]
 git = "https://github.com/paritytech/substrate"
 rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 

--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -1,0 +1,136 @@
+//! This create provides code that is common to all client implementations.
+use parity_scale_codec::Encode;
+use radicle_registry_runtime::UncheckedExtrinsic;
+use sr_primitives::generic::{Era, SignedPayload};
+use sr_primitives::traits::SignedExtension;
+
+pub use radicle_registry_runtime::{
+    registry::{Project, ProjectId},
+    AccountId, Balance,
+};
+pub use substrate_primitives::crypto::{Pair as CryptoPair, Public as CryptoPublic};
+pub use substrate_primitives::ed25519;
+
+pub use radicle_registry_runtime::{Call, Hash, Index, SignedExtra};
+
+/// Return a properly signed [UncheckedExtrinsic] for the given parameters that passes all
+/// validation checks. See the `Checkable` implementation of [UncheckedExtrinsic] for how
+/// validation is performed.
+///
+/// `genesis_hash` is the genesis hash of the block chain this intrinsic is valid for.
+pub fn signed_extrinsic(
+    signer: &ed25519::Pair,
+    call: Call,
+    nonce: Index,
+    genesis_hash: Hash,
+) -> UncheckedExtrinsic {
+    let extra = ExtrinsicExtra {
+        nonce,
+        genesis_hash,
+    };
+    let (runtime_extra, additional_signed) = extra.to_runtime_extra();
+    let raw_payload = SignedPayload::from_raw(call, runtime_extra, additional_signed);
+    let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
+    let (call, extra, _) = raw_payload.deconstruct();
+
+    UncheckedExtrinsic::new_signed(call, signer.public().into(), signature.into(), extra)
+}
+
+#[derive(Clone)]
+/// All data that is necessary to build the [SignedPayload] for a extrinsic.
+struct ExtrinsicExtra {
+    pub nonce: Index,
+    pub genesis_hash: Hash,
+}
+
+impl ExtrinsicExtra {
+    /// Return the [SignedExtra] data that is part of [UncheckedExtrinsic] and the associated
+    /// `AdditionalSigned` data included in the signature.
+    fn to_runtime_extra(
+        &self,
+    ) -> (
+        SignedExtra,
+        <SignedExtra as SignedExtension>::AdditionalSigned,
+    ) {
+        let check_version = srml_system::CheckVersion::new();
+        let check_genesis = srml_system::CheckGenesis::new();
+        let check_era = srml_system::CheckEra::from(Era::Immortal);
+        let check_nonce = srml_system::CheckNonce::from(self.nonce);
+        let check_weight = srml_system::CheckWeight::new();
+        let charge_transaction_payment =
+            srml_transaction_payment::ChargeTransactionPayment::from(0);
+
+        let additional_signed = (
+            check_version
+                .additional_signed()
+                .expect("statically returns ok"),
+            // Genesis hash
+            self.genesis_hash,
+            // Era
+            self.genesis_hash,
+            check_nonce
+                .additional_signed()
+                .expect("statically returns Ok"),
+            check_weight
+                .additional_signed()
+                .expect("statically returns Ok"),
+            charge_transaction_payment
+                .additional_signed()
+                .expect("statically returns Ok"),
+        );
+
+        let extra = (
+            check_version,
+            check_genesis,
+            check_era,
+            check_nonce,
+            check_weight,
+            charge_transaction_payment,
+        );
+
+        (extra, additional_signed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use radicle_registry_runtime::{GenesisConfig, Runtime};
+    use sr_primitives::traits::{Checkable, IdentityLookup};
+    use sr_primitives::BuildStorage as _;
+
+    #[test]
+    /// Assert that extrinsics created with [create_and_sign] are validated by the runtime.
+    fn check_extrinsic() {
+        let genesis_config = GenesisConfig {
+            srml_aura: None,
+            srml_balances: None,
+            srml_sudo: None,
+            system: None,
+        };
+        let mut test_ext = sr_io::TestExternalities::new(genesis_config.build_storage().unwrap());
+        let (key_pair, _) = ed25519::Pair::generate();
+
+        type System = srml_system::Module<Runtime>;
+        let genesis_hash = test_ext.execute_with(|| {
+            System::initialize(
+                &1,
+                &[0u8; 32].into(),
+                &[0u8; 32].into(),
+                &Default::default(),
+            );
+            System::block_hash(0)
+        });
+
+        let xt = signed_extrinsic(
+            &key_pair,
+            srml_system::Call::fill_block().into(),
+            0,
+            genesis_hash,
+        );
+
+        test_ext
+            .execute_with(move || xt.check(&IdentityLookup::default()))
+            .unwrap();
+    }
+}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 radicle_registry_runtime = { path = "../runtime" }
+radicle_registry_client_common = { path = "../client-common" }
 radicle_registry_client_interface = { path = "../client-interface" }
 substrate-subxt = { path = "../subxt" }
 

--- a/client/src/base.rs
+++ b/client/src/base.rs
@@ -4,13 +4,16 @@ use srml_support::storage::generator::{StorageMap, StorageValue};
 use substrate_primitives::ed25519;
 use substrate_primitives::storage::StorageKey;
 
-use radicle_registry_runtime::{Call, Runtime};
+use radicle_registry_client_interface::CryptoPair as _;
+use radicle_registry_runtime::{Call, Hash, Runtime};
+use substrate_subxt::system::SystemStore;
 
 /// Common client errors related to transport, encoding, and validity
 pub type Error = substrate_subxt::Error;
 
 pub struct Client {
     pub(crate) subxt_client: substrate_subxt::Client<Runtime>,
+    genesis_hash: Hash,
 }
 
 pub type ExtrinsicSuccess = substrate_subxt::ExtrinsicSuccess<Runtime>;
@@ -19,7 +22,15 @@ impl Client {
     pub fn create() -> impl Future<Item = Self, Error = Error> {
         substrate_subxt::ClientBuilder::<Runtime>::new()
             .build()
-            .map(|subxt_client| Client { subxt_client })
+            .and_then(|subxt_client| {
+                subxt_client
+                    .connect()
+                    .and_then(|rpc| rpc.genesis_hash())
+                    .map(|genesis_hash| Client {
+                        subxt_client,
+                        genesis_hash,
+                    })
+            })
     }
 
     pub fn fetch_value<S: StorageValue<T>, T: FullCodec>(
@@ -42,8 +53,23 @@ impl Client {
         key_pair: &ed25519::Pair,
         call: impl Into<Call>,
     ) -> impl Future<Item = ExtrinsicSuccess, Error = Error> {
+        let genesis_hash = self.genesis_hash;
+        let call = call.into();
+        let key_pair = key_pair.clone();
+        let account_id = key_pair.public().clone();
+        let subxt_client = self.subxt_client.clone();
         self.subxt_client
-            .xt(key_pair.clone(), None)
-            .and_then(move |xt_builder| xt_builder.set_system_call(call).submit_and_watch())
+            .account_nonce(account_id)
+            .and_then(move |nonce| {
+                let xt = radicle_registry_client_common::signed_extrinsic(
+                    &key_pair,
+                    call,
+                    nonce,
+                    genesis_hash,
+                );
+                subxt_client
+                    .connect()
+                    .and_then(move |rpc| rpc.submit_and_watch_extrinsic(xt))
+            })
     }
 }

--- a/subxt/src/lib.rs
+++ b/subxt/src/lib.rs
@@ -145,7 +145,8 @@ impl<T: System> Clone for Client<T> {
 }
 
 impl<T: System + Balances + 'static> Client<T> {
-    fn connect(&self) -> impl Future<Item = Rpc<T>, Error = Error> {
+    /// Connect a new RPC client and return it.
+    pub fn connect(&self) -> impl Future<Item = Rpc<T>, Error = Error> {
         connect(&self.url)
     }
 


### PR DESCRIPTION
As a first step towards better transaction utilities we extract the transaction creation and signing logic from `subxt` into the `radicle_registry_client_common` crate.