### PR TITLE
Add 'submit' method to 'Client' trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ name = "radicle_registry_client_common"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
+ "radicle_registry_client_interface",
  "radicle_registry_runtime",
  "sr-io",
  "sr-primitives",
@@ -2981,11 +2982,13 @@ name = "radicle_registry_memory_client"
 version = "0.1.0"
 dependencies = [
  "futures01",
+ "radicle_registry_client_common",
  "radicle_registry_client_interface",
  "radicle_registry_runtime",
  "sr-io",
  "sr-primitives",
  "srml-support",
+ "srml-system",
  "substrate-primitives",
 ]
 

--- a/client-common/Cargo.toml
+++ b/client-common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 radicle_registry_runtime = { path = "../runtime" }
+radicle_registry_client_interface = { path = "../client-interface" }
 
 parity-scale-codec = "1.0"
 

--- a/client/src/base.rs
+++ b/client/src/base.rs
@@ -5,8 +5,8 @@ use substrate_primitives::ed25519;
 use substrate_primitives::storage::StorageKey;
 
 use radicle_registry_client_interface::CryptoPair as _;
-use radicle_registry_runtime::{Call, Hash, Runtime};
-use substrate_subxt::system::SystemStore;
+use radicle_registry_runtime::{Call as RuntimeCall, Hash, Runtime};
+use substrate_subxt::system::SystemStore as _;
 
 /// Common client errors related to transport, encoding, and validity
 pub type Error = substrate_subxt::Error;
@@ -51,7 +51,7 @@ impl Client {
     pub fn submit_and_watch_call(
         &self,
         key_pair: &ed25519::Pair,
-        call: impl Into<Call>,
+        call: RuntimeCall,
     ) -> impl Future<Item = ExtrinsicSuccess, Error = Error> {
         let genesis_hash = self.genesis_hash;
         let call = call.into();

--- a/client/src/with_executor.rs
+++ b/client/src/with_executor.rs
@@ -28,25 +28,14 @@ impl ClientWithExecutor {
 }
 
 impl ClientT for ClientWithExecutor {
-    fn transfer(
-        &self,
-        key_pair: &ed25519::Pair,
-        receiver: &AccountId,
-        balance: Balance,
-    ) -> Response<(), Error> {
-        self.run_sync(move |client| client.transfer(key_pair, receiver, balance))
+    /// Sign and submit a ledger call as a transaction to the blockchain. Returns the hash of the
+    /// transaction once it has been included in a block.
+    fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TxHash, Error> {
+        self.run_sync(move |client| client.submit(author, call))
     }
 
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error> {
         self.run_sync(move |client| client.free_balance(account_id))
-    }
-
-    fn register_project(
-        &self,
-        author: &ed25519::Pair,
-        project_params: RegisterProjectParams,
-    ) -> Response<(), Error> {
-        self.run_sync(move |client| client.register_project(author, project_params))
     }
 
     fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Error> {
@@ -55,15 +44,6 @@ impl ClientT for ClientWithExecutor {
 
     fn list_projects(&self) -> Response<Vec<ProjectId>, Error> {
         self.run_sync(move |client| client.list_projects())
-    }
-
-    fn create_checkpoint(
-        &self,
-        author: &ed25519::Pair,
-        project_hash: H256,
-        prev_cp: Option<CheckpointId>,
-    ) -> Response<CheckpointId, Error> {
-        self.run_sync(move |client| client.create_checkpoint(author, project_hash, prev_cp))
     }
 
     fn get_checkpoint(&self, id: CheckpointId) -> Response<Option<Checkpoint>, Error> {

--- a/memory-client/Cargo.toml
+++ b/memory-client/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 radicle_registry_runtime = { path = "../runtime" }
 radicle_registry_client_interface = { path = "../client-interface" }
+radicle_registry_client_common = { path = "../client-common" }
 
 futures01 = "0.1"
 
@@ -21,6 +22,10 @@ git = "https://github.com/paritytech/substrate"
 rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 
 [dependencies.srml-support]
+git = "https://github.com/paritytech/substrate"
+rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
+
+[dependencies.srml-system]
 git = "https://github.com/paritytech/substrate"
 rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,7 +52,12 @@ pub type Balance = u128;
 /// Index of a transaction in the chain.
 pub type Index = u32;
 
+/// The hashing algorightm to use
+pub type Hashing = BlakeTwo256;
+
 /// A hash of some data used by the chain.
+///
+/// Same as [Hashing::Output].
 pub type Hash = substrate_primitives::H256;
 
 /// Digest item type.
@@ -131,7 +136,7 @@ impl srml_system::Trait for Runtime {
     /// The type for hashing blocks and tries.
     type Hash = Hash;
     /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
+    type Hashing = Hashing;
     /// The header type.
     type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// The ubiquitous event type.

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -53,6 +53,13 @@ pub struct Checkpoint {
     pub hash: H256,
 }
 
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct CreateCheckpointParams {
+    pub checkpoint_id: CheckpointId,
+    pub project_hash: H256,
+    pub previous_checkpoint: Option<CheckpointId>,
+}
+
 pub trait Trait: srml_system::Trait<AccountId = AccountId, Origin = crate::Origin> {
     type Event: From<Event> + Into<<Self as srml_system::Trait>::Event>;
 }
@@ -97,18 +104,16 @@ decl_module! {
         #[weight = SimpleDispatchInfo::FreeNormal]
         pub fn create_checkpoint(
             origin,
-            project_hash: H256,
-            checkpoint_id: CheckpointId,
-            prev_checkpoint_id: Option<CheckpointId>,
+            params: CreateCheckpointParams,
         ) -> Result {
             ensure_signed(origin)?;
             let checkpoint = Checkpoint {
-                parent: prev_checkpoint_id,
-                hash: project_hash,
+                parent: params.previous_checkpoint,
+                hash: params.project_hash,
             };
-            store::Checkpoints::insert(checkpoint_id, checkpoint);
+            store::Checkpoints::insert(params.checkpoint_id, checkpoint);
 
-            Self::deposit_event(Event::CheckpointCreated(checkpoint_id));
+            Self::deposit_event(Event::CheckpointCreated(params.checkpoint_id));
             Ok(())
         }
     }


### PR DESCRIPTION
We add a `submit` method to the `Client` trait that is responsible for submitting any transaction. The `Client` transaction methods (`transfer`, `register_project`) are now implemented using of `submit` on the `Client` trait itself.

For `submit` we also introduce the `Call` enum that represents ledger calls.