### PR TITLE
Add 'get_transaction_extra' method to 'Client' trait

### DIFF
--- a/client-interface/src/lib.rs
+++ b/client-interface/src/lib.rs
@@ -14,7 +14,7 @@ pub use radicle_registry_runtime::{
     registry::{
         Checkpoint, CheckpointId, CreateCheckpointParams, Project, ProjectId, RegisterProjectParams,
     },
-    AccountId, Balance,
+    AccountId, Balance, Index,
 };
 pub use substrate_primitives::crypto::{Pair as CryptoPair, Public as CryptoPublic};
 pub use substrate_primitives::{ed25519, H256};
@@ -25,6 +25,13 @@ pub type Error = substrate_subxt::Error;
 #[doc(inline)]
 /// The hash of a transaction. Uniquely identifies a transaction.
 pub type TxHash = Hash;
+
+#[derive(Copy, Clone)]
+/// All data that is necessary to build the [SignedPayload] for a extrinsic.
+pub struct TransactionExtra {
+    pub nonce: Index,
+    pub genesis_hash: Hash,
+}
 
 #[derive(Clone, Debug)]
 pub struct TransferParams {
@@ -50,6 +57,8 @@ pub trait Client {
     /// Sign and submit a ledger call as a transaction to the blockchain. Returns the hash of the
     /// transaction once it has been included in a block.
     fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TxHash, Error>;
+
+    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error>;
 
     fn transfer(
         &self,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,12 +7,8 @@ use substrate_subxt::balances::BalancesStore as _;
 mod base;
 mod with_executor;
 
+pub use radicle_registry_client_interface::{Client as ClientT, *};
 pub use radicle_registry_runtime::counter::CounterValue;
-
-pub use radicle_registry_client_interface::{
-    ed25519, AccountId, Balance, Call, Checkpoint, CheckpointId, Client as ClientT, CryptoPair,
-    CryptoPublic, Project, ProjectId, RegisterProjectParams, Response, TxHash, H256,
-};
 
 pub use base::Error;
 pub use with_executor::ClientWithExecutor;
@@ -34,7 +30,7 @@ impl Client {
 
     pub fn counter_inc(&self, key_pair: &ed25519::Pair) -> impl Future<Item = (), Error = Error> {
         self.base_client
-            .submit_and_watch_call(key_pair, counter::Call::inc().into())
+            .submit_runtime_call(key_pair, counter::Call::inc().into())
             .map(|_| ())
     }
 
@@ -47,12 +43,16 @@ impl ClientT for Client {
     fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TxHash, Error> {
         Box::new(
             self.base_client
-                .submit_and_watch_call(
+                .submit_runtime_call(
                     author,
                     radicle_registry_client_common::into_runtime_call(call),
                 )
                 .map(|xt| xt.extrinsic),
         )
+    }
+
+    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error> {
+        self.base_client.get_transaction_extra(account_id)
     }
 
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error> {

--- a/client/src/with_executor.rs
+++ b/client/src/with_executor.rs
@@ -34,6 +34,10 @@ impl ClientT for ClientWithExecutor {
         self.run_sync(move |client| client.submit(author, call))
     }
 
+    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error> {
+        self.run_sync(move |client| client.get_transaction_extra(account_id))
+    }
+
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error> {
         self.run_sync(move |client| client.free_balance(account_id))
     }


### PR DESCRIPTION
We add the `get_transaction_extra` method to the `Client` trait. This method was internal to the clients before and is part of the signing interface for clients.