### PR TITLE
Align storage value retrieval in Client

### DIFF
--- a/client/src/base.rs
+++ b/client/src/base.rs
@@ -34,19 +34,23 @@ impl Client {
             })
     }
 
-    pub fn fetch_value<S: StorageValue<T>, T: FullCodec>(
+    pub fn fetch_value<S: StorageValue<Value>, Value: FullCodec>(
         &self,
-    ) -> impl Future<Item = Option<T>, Error = Error> {
-        let key = StorageKey(Vec::from(&S::storage_value_final_key()[..]));
-        self.subxt_client.fetch::<T>(key)
+    ) -> impl Future<Item = S::Query, Error = Error> {
+        let key = StorageKey(Vec::from(S::storage_value_final_key().as_ref()));
+        self.subxt_client
+            .fetch::<Value>(key)
+            .map(|maybe_value| S::from_optional_value_to_query(maybe_value))
     }
 
     pub fn fetch_map_value<S: StorageMap<Key, Value>, Key: FullCodec, Value: FullCodec>(
         &self,
         key: Key,
-    ) -> impl Future<Item = Option<Value>, Error = Error> {
+    ) -> impl Future<Item = S::Query, Error = Error> {
         let key = StorageKey(Vec::from(S::storage_map_final_key(key).as_ref()));
-        self.subxt_client.fetch::<Value>(key)
+        self.subxt_client
+            .fetch::<Value>(key)
+            .map(|maybe_value| S::from_optional_value_to_query(maybe_value))
     }
 
     pub fn get_transaction_extra(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,8 +1,7 @@
 //! Node client for the radicle registry
 use futures01::prelude::*;
 
-use radicle_registry_runtime::registry;
-use substrate_subxt::balances::BalancesStore as _;
+use radicle_registry_runtime::{balances, registry, Runtime};
 
 mod base;
 mod with_executor;
@@ -47,10 +46,10 @@ impl ClientT for Client {
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error> {
         Box::new(
             self.base_client
-                .subxt_client
-                .free_balance(account_id.clone()),
+                .fetch_map_value::<balances::FreeBalance<Runtime>, _, _>(account_id.clone()),
         )
     }
+
     fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Error> {
         Box::new(
             self.base_client
@@ -61,8 +60,7 @@ impl ClientT for Client {
     fn list_projects(&self) -> Response<Vec<ProjectId>, Error> {
         Box::new(
             self.base_client
-                .fetch_value::<registry::store::ProjectIds, _>()
-                .map(|maybe_ids| maybe_ids.unwrap_or_default()),
+                .fetch_value::<registry::store::ProjectIds, _>(),
         )
     }
 


### PR DESCRIPTION
We change the implementation of `free_balance` in the node `Client` to use the `fetch_map_value` method like all other storage lookups.

This requires us to adjust the `fetch_*` methods to incorporate conversion from `Option` values.