### PR TITLE
Return events from 'Client::submit'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,7 @@ dependencies = [
  "radicle_registry_client_common",
  "radicle_registry_client_interface",
  "radicle_registry_runtime",
+ "sr-primitives",
  "srml-support",
  "srml-system",
  "substrate-primitives",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,3 +29,6 @@ rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 git = "https://github.com/paritytech/substrate"
 rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"
 
+[dependencies.sr-primitives]
+git = "https://github.com/paritytech/substrate"
+rev = "14345ac157f656ac032d2566b0a2dfb005b32c60"

--- a/client/src/with_executor.rs
+++ b/client/src/with_executor.rs
@@ -30,7 +30,7 @@ impl ClientWithExecutor {
 impl ClientT for ClientWithExecutor {
     /// Sign and submit a ledger call as a transaction to the blockchain. Returns the hash of the
     /// transaction once it has been included in a block.
-    fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TxHash, Error> {
+    fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TransactionApplied, Error> {
         self.run_sync(move |client| client.submit(author, call))
     }
 

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -4,7 +4,8 @@
 
 use futures01::future::Future as _;
 use radicle_registry_client::{
-    ed25519, Checkpoint, ClientT as _, ClientWithExecutor, CryptoPair, RegisterProjectParams, H256,
+    ed25519, Call, Checkpoint, ClientT as _, ClientWithExecutor, CryptoPair, RegisterProjectParams,
+    RegistryEvent, H256,
 };
 
 #[test]
@@ -19,18 +20,23 @@ fn register_project() {
         .wait()
         .unwrap();
     let project_id = ("NAME".to_string(), "DOMAIN".to_string());
-    client
-        .register_project(
+    let tx_applied = client
+        .submit(
             &alice,
-            RegisterProjectParams {
+            Call::RegisterProject(RegisterProjectParams {
                 id: project_id.clone(),
                 description: "DESCRIPTION".to_string(),
                 img_url: "IMG_URL".to_string(),
                 checkpoint_id,
-            },
+            }),
         )
         .wait()
         .unwrap();
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::ProjectRegistered(project_id.clone()).into()
+    );
 
     let project = client
         .get_project(project_id.clone())

--- a/runtime/tests/main.rs
+++ b/runtime/tests/main.rs
@@ -4,7 +4,8 @@
 use futures::prelude::*;
 
 use radicle_registry_memory_client::{
-    ed25519, Checkpoint, Client, CryptoPair, MemoryClient, RegisterProjectParams, H256,
+    ed25519, Call, Checkpoint, Client, CryptoPair, MemoryClient, RegisterProjectParams,
+    RegistryEvent, H256,
 };
 
 #[test]
@@ -18,18 +19,23 @@ fn register_project() {
         .wait()
         .unwrap();
     let project_id = ("NAME".to_string(), "DOMAIN".to_string());
-    client
-        .register_project(
+    let tx_applied = client
+        .submit(
             &alice,
-            RegisterProjectParams {
+            Call::RegisterProject(RegisterProjectParams {
                 id: project_id.clone(),
                 description: "DESCRIPTION".to_string(),
                 img_url: "IMG_URL".to_string(),
                 checkpoint_id,
-            },
+            }),
         )
         .wait()
         .unwrap();
+
+    assert_eq!(
+        tx_applied.events[1],
+        RegistryEvent::ProjectRegistered(project_id.clone()).into()
+    );
 
     let project = client
         .get_project(project_id.clone())


### PR DESCRIPTION
We introduce the `TransactionApplied` type that is returned from `Client::submit`. This gives client users the change to inspect events emitted by the submitted transaction.