### PR TITLE
Add 'fetch_X_value' to 'MemoryClient'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ name = "radicle_registry_memory_client"
 version = "0.1.0"
 dependencies = [
  "futures01",
+ "parity-scale-codec",
  "radicle_registry_client_common",
  "radicle_registry_client_interface",
  "radicle_registry_runtime",

--- a/memory-client/Cargo.toml
+++ b/memory-client/Cargo.toml
@@ -12,6 +12,7 @@ radicle_registry_client_interface = { path = "../client-interface" }
 radicle_registry_client_common = { path = "../client-common" }
 
 futures01 = "0.1"
+parity-scale-codec = "1.0"
 
 [dependencies.substrate-primitives]
 git = "https://github.com/paritytech/substrate"


### PR DESCRIPTION
We add the `fetch_value` and `fetch_map_value` methods to the `MemoryClient` and implement all storage methods on the `MemoryClient` using the new methods.

This makes the memory client more similar to the real client which provides some opportunities to reduce code duplication.