### PR TITLE
Implement project accounts

### DIFF
--- a/client-interface/src/call.rs
+++ b/client-interface/src/call.rs
@@ -30,7 +30,9 @@ impl Call for registry::RegisterProjectParams {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "ProjectRegistered", |event| match event {
-                Event::registry(registry::Event::ProjectRegistered(_project_id)) => Some(Ok(())),
+                Event::registry(registry::Event::ProjectRegistered(_project_id, _account_id)) => {
+                    Some(Ok(()))
+                }
                 _ => None,
             }),
             Err(dispatch_error) => Ok(Err(dispatch_error.message)),
@@ -92,6 +94,19 @@ impl Call for crate::TransferParams {
 
     fn into_runtime_call(self) -> RuntimeCall {
         balances::Call::transfer(self.recipient, self.balance).into()
+    }
+}
+
+impl Call for registry::TransferFromProjectParams {
+    type Result = Result<(), Option<&'static str>>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        Ok(dispatch_result.map_err(|dispatch_error| dispatch_error.message))
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::transfer_from_project(self).into()
     }
 }
 

--- a/client-interface/src/lib.rs
+++ b/client-interface/src/lib.rs
@@ -14,7 +14,7 @@ pub use radicle_registry_runtime::{
     registry::{
         Checkpoint, CheckpointId, CreateCheckpointParams, Event as RegistryEvent, Project,
         ProjectDomain, ProjectId, ProjectName, RegisterProjectParams, SetCheckpointParams,
-        String32,
+        String32, TransferFromProjectParams,
     },
     AccountId, Balance, Event, Index,
 };

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -39,11 +39,6 @@ fn register_project() {
 
     assert_eq!(tx_applied.result, Ok(()));
 
-    assert_eq!(
-        tx_applied.events[0],
-        RegistryEvent::ProjectRegistered(project_id.clone()).into()
-    );
-
     let project = client
         .get_project(project_id.clone())
         .wait()
@@ -53,6 +48,11 @@ fn register_project() {
     assert_eq!(project.description, "DESCRIPTION");
     assert_eq!(project.img_url, "IMG_URL");
     assert_eq!(project.current_cp, checkpoint_id);
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::ProjectRegistered(project_id.clone(), project.account_id.clone()).into()
+    );
 
     let checkpoint = client
         .get_checkpoint(checkpoint_id)


### PR DESCRIPTION
Every project is now associated with an account. When a project is registered we create a random account ID. We also implement a function that allows the project owner to transfer money from the project account to another user.