### PR TITLE
Return call result from 'Client::submit'

### DIFF
--- a/client-common/src/lib.rs
+++ b/client-common/src/lib.rs
@@ -1,7 +1,6 @@
 //! This create provides code that is common to all client implementations.
 use parity_scale_codec::Encode;
 use radicle_registry_runtime::UncheckedExtrinsic;
-use radicle_registry_runtime::{balances, registry};
 use sr_primitives::generic::{Era, SignedPayload};
 use sr_primitives::traits::SignedExtension;
 
@@ -36,16 +35,6 @@ pub fn signed_extrinsic(
     let (call, extra, _) = raw_payload.deconstruct();
 
     UncheckedExtrinsic::new_signed(call, signer.public(), signature, extra)
-}
-
-/// Transforms a public ledger call into an internal runtime call.
-pub fn into_runtime_call(call: Call) -> RuntimeCall {
-    match call {
-        Call::RegisterProject(params) => registry::Call::register_project(params).into(),
-        Call::Transfer(params) => balances::Call::transfer(params.recipient, params.balance).into(),
-        Call::CreateCheckpoint(params) => registry::Call::create_checkpoint(params).into(),
-        Call::SetCheckpoint(params) => registry::Call::set_checkpoint(params).into(),
-    }
 }
 
 /// Return the [SignedExtra] data that is part of [UncheckedExtrinsic] and the associated

--- a/client-interface/src/call.rs
+++ b/client-interface/src/call.rs
@@ -1,0 +1,130 @@
+//! Defines [Call] trait and implementations for all transaction parameters.
+
+use radicle_registry_runtime::{balances, registry, Call as RuntimeCall, Event};
+use sr_primitives::DispatchError;
+
+/// Indicates that parsing the events into the approriate call result failed.
+type EventParseError = String;
+
+/// Trait implemented for every runtime call.
+///
+/// For every [RuntimeCall] that is exposed to the user we implement [Call] for the parameters
+/// struct of the runtime call.
+pub trait Call: Send + 'static {
+    /// Result of executing the call in the runtime that is presented to the client user.
+    type Result: Send + 'static;
+
+    /// Parse all runtime events emitted by the call and return the appropriate call result.
+    ///
+    /// Returns an error if the event list is not well formed. For example if an expected event is
+    /// missing.
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError>;
+
+    fn into_runtime_call(self) -> RuntimeCall;
+}
+
+impl Call for registry::RegisterProjectParams {
+    type Result = Result<(), Option<&'static str>>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "ProjectRegistered", |event| match event {
+                Event::registry(registry::Event::ProjectRegistered(_project_id)) => Some(Ok(())),
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error.message)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::register_project(self).into()
+    }
+}
+
+impl Call for registry::CreateCheckpointParams {
+    type Result = Result<(), Option<&'static str>>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "CheckpointCreated", |event| match event {
+                Event::registry(registry::Event::CheckpointCreated(_checkpoint_id)) => Some(Ok(())),
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error.message)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::create_checkpoint(self).into()
+    }
+}
+
+impl Call for registry::SetCheckpointParams {
+    type Result = Result<(), Option<&'static str>>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "CheckpointSet", |event| match event {
+                Event::registry(registry::Event::CheckpointSet(_project_id, _checkpoint_id)) => {
+                    Some(Ok(()))
+                }
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error.message)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::set_checkpoint(self).into()
+    }
+}
+
+impl Call for crate::TransferParams {
+    type Result = Result<(), Option<&'static str>>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        Ok(dispatch_result.map_err(|dispatch_error| dispatch_error.message))
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        balances::Call::transfer(self.recipient, self.balance).into()
+    }
+}
+
+/// Extract the dispatch result of an extrinsic from the extrinsic events.
+///
+/// Looks for the [paint_system::Event] in the list of events and returns the inner result based on
+/// the event.
+///
+/// Returns an outer [EventParseError] if no [paint_system::Event] was present in `events`.
+///
+/// Because of an issue with substrate the `message` field of [DispatchError] will always be `None`
+fn get_dispatch_result(events: &Vec<Event>) -> Result<Result<(), DispatchError>, EventParseError> {
+    find_event(events, "System", |event| match event {
+        Event::system(system_event) => match system_event {
+            paint_system::Event::ExtrinsicSuccess => Some(Ok(())),
+            paint_system::Event::ExtrinsicFailed(ref dispatch_error) => {
+                Some(Err(dispatch_error.clone()))
+            }
+        },
+        _ => None,
+    })
+}
+
+/// Applies function to the elements of iterator and returns the first non-none result.
+///
+/// Returns an error if no matching element was found.
+fn find_event<T>(
+    events: &Vec<Event>,
+    event_name: &'static str,
+    f: impl Fn(&Event) -> Option<T>,
+) -> Result<T, EventParseError> {
+    events
+        .iter()
+        .find_map(f)
+        .ok_or(format!("{} event is missing", event_name))
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -28,23 +28,28 @@ impl Client {
 }
 
 impl ClientT for Client {
-    fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TransactionApplied, Error> {
+    fn submit<Call_: Call>(
+        &self,
+        author: &ed25519::Pair,
+        call: Call_,
+    ) -> Response<TransactionApplied<Call_>, Error> {
         let base_client = self.base_client.clone();
         Box::new(
             self.base_client
-                .submit_runtime_call(
-                    author,
-                    radicle_registry_client_common::into_runtime_call(call),
-                )
+                .submit_runtime_call(author, call.into_runtime_call())
                 .and_then(move |ext_success| {
                     let tx_hash = ext_success.extrinsic;
                     let block = ext_success.block;
                     base_client
                         .extract_events(ext_success)
-                        .map(move |events| TransactionApplied {
-                            tx_hash,
-                            block,
-                            events,
+                        .and_then(move |events| {
+                            let result = Call_::result_from_events(events.clone())?;
+                            Ok(TransactionApplied {
+                                tx_hash,
+                                block,
+                                events,
+                                result,
+                            })
                         })
                 }),
         )

--- a/client/src/with_executor.rs
+++ b/client/src/with_executor.rs
@@ -30,7 +30,11 @@ impl ClientWithExecutor {
 impl ClientT for ClientWithExecutor {
     /// Sign and submit a ledger call as a transaction to the blockchain. Returns the hash of the
     /// transaction once it has been included in a block.
-    fn submit(&self, author: &ed25519::Pair, call: Call) -> Response<TransactionApplied, Error> {
+    fn submit<Call_: Call>(
+        &self,
+        author: &ed25519::Pair,
+        call: Call_,
+    ) -> Response<TransactionApplied<Call_>, Error> {
         self.run_sync(move |client| client.submit(author, call))
     }
 

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -4,7 +4,7 @@
 
 use futures01::future::Future as _;
 use radicle_registry_client::{
-    ed25519, Call, Checkpoint, ClientT as _, ClientWithExecutor, CryptoPair, RegisterProjectParams,
+    ed25519, Checkpoint, ClientT as _, ClientWithExecutor, CryptoPair, RegisterProjectParams,
     RegistryEvent, H256,
 };
 use radicle_registry_runtime::registry::{ProjectDomain, ProjectName};
@@ -27,15 +27,17 @@ fn register_project() {
     let tx_applied = client
         .submit(
             &alice,
-            Call::RegisterProject(RegisterProjectParams {
+            RegisterProjectParams {
                 id: project_id.clone(),
                 description: "DESCRIPTION".to_string(),
                 img_url: "IMG_URL".to_string(),
                 checkpoint_id,
-            }),
+            },
         )
         .wait()
         .unwrap();
+
+    assert_eq!(tx_applied.result, Ok(()));
 
     assert_eq!(
         tx_applied.events[0],

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,10 +22,12 @@ std = [
     "paint-timestamp/std",
     "paint-transaction-payment/std",
     "sr-api/std",
+    "substrate-block-builder-runtime-api/std",
     "substrate-consensus-aura-primitives/std",
     "substrate-offchain-primitives/std",
     "substrate-primitives/std",
     "substrate-session/std",
+    "substrate-transaction-pool-runtime-api/std",
 ]
 
 [dependencies.codec]


### PR DESCRIPTION
We change `TransactionApplied` returned by `Client::submit` so that it includes the result of the call submitted.

This is accomplished by changing the call argument to `submit` from an enum to a trait. This new `Call` trait is implemented for all runtime calls, i.e. the variants that made up the `Call` enum before. The `Call` trait has an associated `Result` type that specifies the result of a runtime call.

Currently the result type for all calls is `Result<(), &'static str>` which maps one to one to the `DispatchResult` of a method in the runtime definition. In the future we’ll provide proper return values.