### PR TITLE
Checkpoint hash change

### DIFF
--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -12,12 +12,13 @@ pub use radicle_registry_runtime::{
         ProjectDomain, ProjectId, ProjectName, RegisterProjectParams, SetCheckpointParams,
         String32, TransferFromProjectParams,
     },
-    AccountId, Balance, Event, Index,
+    AccountId, Balance, Event, Hashing, Index,
 };
 pub use substrate_primitives::crypto::{Pair as CryptoPair, Public as CryptoPublic};
 pub use substrate_primitives::{ed25519, H256};
 
 pub use crate::call::Call;
+pub use sr_primitives::traits::Hash as _;
 
 #[doc(inline)]
 pub type Error = substrate_subxt::Error;
@@ -109,12 +110,14 @@ pub trait Client {
         project_hash: H256,
         previous_checkpoint_id: Option<CheckpointId>,
     ) -> Response<CheckpointId, Error> {
-        let checkpoint_id = CheckpointId::random();
+        let checkpoint_id = Hashing::hash_of(&Checkpoint {
+            parent: previous_checkpoint_id,
+            hash: project_hash,
+        });
         Box::new(
             self.submit(
                 author,
                 CreateCheckpointParams {
-                    checkpoint_id,
                     project_hash,
                     previous_checkpoint_id,
                 },

--- a/client/src/memory.rs
+++ b/client/src/memory.rs
@@ -8,7 +8,7 @@ use parity_scale_codec::{Decode, FullCodec};
 use sr_primitives::{traits::Hash as _, BuildStorage as _};
 
 use radicle_registry_runtime::{
-    balances, registry, BalancesConfig, Executive, GenesisConfig, Hash, Hashing, Runtime,
+    balances, registry, BalancesConfig, Executive, GenesisConfig, Hash, Runtime,
 };
 
 use crate::interface::*;

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -19,7 +19,8 @@ use substrate_primitives::{crypto::UncheckedFrom, H256};
 use paint_system as system;
 use paint_system::ensure_signed;
 
-use crate::{AccountId, Balance, Hash};
+use crate::{AccountId, Balance, Hash, Hashing};
+use sr_primitives::traits::Hash as _;
 
 /// Type to represent project names and domains.
 ///
@@ -122,7 +123,6 @@ pub struct Checkpoint {
 
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct CreateCheckpointParams {
-    pub checkpoint_id: CheckpointId,
     pub project_hash: H256,
     pub previous_checkpoint_id: Option<CheckpointId>,
 }
@@ -265,9 +265,10 @@ decl_module! {
                 parent: params.previous_checkpoint_id,
                 hash: params.project_hash,
             };
-            store::Checkpoints::insert(params.checkpoint_id, checkpoint);
+            let checkpoint_id = Hashing::hash_of(&checkpoint);
+            store::Checkpoints::insert(checkpoint_id, checkpoint);
 
-            Self::deposit_event(Event::CheckpointCreated(params.checkpoint_id));
+            Self::deposit_event(Event::CheckpointCreated(checkpoint_id));
             Ok(())
         }
 

--- a/runtime/tests/main.rs
+++ b/runtime/tests/main.rs
@@ -205,7 +205,6 @@ fn create_checkpoint_without_parent() {
     let client = MemoryClient::new();
     let bob = key_pair_from_string("Bob");
 
-    let checkpoint_id = CheckpointId::random();
     let project_hash = H256::random();
     let previous_checkpoint_id = Some(CheckpointId::random());
 
@@ -213,7 +212,6 @@ fn create_checkpoint_without_parent() {
         .submit(
             &bob,
             CreateCheckpointParams {
-                checkpoint_id,
                 project_hash,
                 previous_checkpoint_id,
             },


### PR DESCRIPTION
Closes #53.

Checkpoint IDs are now a hash of the checkpoint's contents.