### PR TITLE
Validate registration checkpoint

### DIFF
--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -199,6 +199,15 @@ decl_module! {
         #[weight = SimpleDispatchInfo::FreeNormal]
         pub fn register_project(origin, params: RegisterProjectParams) -> DispatchResult {
             let sender = ensure_signed(origin)?;
+
+            if store::Checkpoints::get(params.checkpoint_id).is_none() {
+                return Err("The checkpoint provided to register the project does not exist.")
+            }
+            match store::Projects::get(params.id.clone()) {
+                None => {}
+                Some (_) => return Err("A project with the supplied ID already exists."),
+            };
+
             let project_id = params.id.clone();
             match store::Projects::get(project_id.clone()) {
                 None => {}

--- a/runtime/tests/main.rs
+++ b/runtime/tests/main.rs
@@ -116,6 +116,33 @@ fn register_project_with_duplicate_id() {
 }
 
 #[test]
+fn register_project_with_bad_checkpoint() {
+    let client = MemoryClient::new();
+    let alice = key_pair_from_string("Alice");
+
+    let checkpoint_id = H256::random();
+    let project_id = (
+        ProjectName::from_string("NAME".to_string()).unwrap(),
+        ProjectDomain::from_string("DOMAIN".to_string()).unwrap(),
+    );
+
+    let params = RegisterProjectParams {
+        id: project_id.clone(),
+        description: "DESCRIPTION".to_string(),
+        img_url: "IMG_URL".to_string(),
+        checkpoint_id,
+    };
+
+    let tx_applied = client.submit(&alice, params).wait().unwrap();
+
+    assert_eq!(tx_applied.result, Err(None));
+
+    let no_project = client.get_project(project_id).wait().unwrap();
+
+    assert!(no_project.is_none())
+}
+
+#[test]
 fn long_string32() {
     fn long_string(n: usize) -> Result<String32, String> {
         String32::from_string(std::iter::repeat("X").take(n).collect::<String>())


### PR DESCRIPTION
When registering a project, the provided checkpoint was not validated. This is now done, and a test for this feature has been added to `runtime/tests/main.rs`.