### PR TITLE
Refactor registration parameter creation in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
  "paint-transaction-payment",
  "parity-scale-codec",
  "radicle_registry_client",
+ "rand 0.7.2",
  "serde",
  "sr-api",
  "sr-io",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -153,4 +153,5 @@ substrate-wasm-builder-runner = "1.0.2"
 
 [dev-dependencies]
 futures = "0.1"
+rand = "0.7.2"
 radicle_registry_client = { path = "../client" }


### PR DESCRIPTION
Closes #86.

Project registration parameters in tests are now generated by a separate function, reducing duplicate code across some test cases.