### PR TITLE
No code in client trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You’ll need to build the client with Rust Nightly.
 To build and view the client documentation run `./scripts/build-client-docs
 --open`.
 
+You can find examples in the `./client/examples` directory.
+
 
 Account Keys
 ------------


### PR DESCRIPTION
We remove all code of the default implementations from the client trait. We also rename the client trait from `Client` to `ClientT`. This does not change the external API because we already exposed the client trait as `ClientT`.