### PR TITLE
Add offline transaction signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,11 @@ Upcoming
 * Eliminate `ClientWithExecutor`, use `Client::create_with_executor()` instead.
 * Eliminate `MemoryClient`. The memory client is now called the emulator and can
   be created with `Client::new_emulator()`.
+
+### Addition
+
+* Offline transaction signing with the following new APIs
+  * `ClientT::account_nonce()`
+  * `ClientT::genesis_hash()`
+  * `Transaction`
+  * `Transaction::new_signed()`

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -1,0 +1,37 @@
+use futures01::future::Future;
+use futures03::compat::{Compat, Future01CompatExt};
+use futures03::future::FutureExt;
+
+use radicle_registry_client::{
+    ed25519, Client, ClientT as _, CryptoPair as _, Error, Transaction, TransactionExtra,
+    TransferParams,
+};
+
+fn main() {
+    env_logger::init();
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(Compat::new(go().boxed())).unwrap();
+    runtime.shutdown_now().wait().unwrap();
+}
+
+async fn go() -> Result<(), Error> {
+    let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
+    let bob = ed25519::Pair::from_string("//Bob", None).unwrap();
+    let client = Client::create().compat().await?;
+
+    let account_nonce = client.account_nonce(&alice.public()).compat().await?;
+    let transfer_tx = Transaction::new_signed(
+        &alice,
+        TransferParams {
+            recipient: bob.public(),
+            balance: 1000,
+        },
+        TransactionExtra {
+            nonce: account_nonce,
+            genesis_hash: client.genesis_hash(),
+        },
+    );
+
+    client.submit_transaction(transfer_tx).compat().await?;
+    Ok(())
+}

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -64,18 +64,12 @@ impl backend::Backend for Emulator {
 
     fn fetch(&self, key: &[u8]) -> Response<Option<Vec<u8>>, Error> {
         let test_ext = &mut self.test_ext.lock().unwrap();
-        let maybe_data = test_ext.execute_with(|| sr_io::storage::get(key.as_ref()));
+        let maybe_data = test_ext.execute_with(|| sr_io::storage::get(key));
         Box::new(future::ok(maybe_data))
     }
 
-    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error> {
-        let test_ext = &mut self.test_ext.lock().unwrap();
-        let nonce =
-            test_ext.execute_with(|| paint_system::Module::<Runtime>::account_nonce(account_id));
-        Box::new(future::ok(TransactionExtra {
-            nonce,
-            genesis_hash: self.genesis_hash,
-        }))
+    fn get_genesis_hash(&self) -> Hash {
+        self.genesis_hash
     }
 }
 

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -1,7 +1,5 @@
 //! Define trait for client backends and provide emulator and remote node implementation
-use radicle_registry_runtime::Hash;
-
-pub use radicle_registry_runtime::UncheckedExtrinsic;
+pub use radicle_registry_runtime::{Hash, UncheckedExtrinsic};
 
 use crate::interface::*;
 
@@ -36,6 +34,6 @@ pub trait Backend {
     /// Fetch a value from the runtime state storage.
     fn fetch(&self, key: &[u8]) -> Response<Option<Vec<u8>>, Error>;
 
-    /// Get transaction extra from current ledger state to create valid transactions.
-    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error>;
+    /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
+    fn get_genesis_hash(&self) -> Hash;
 }

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -3,10 +3,7 @@ use futures01::future::Future;
 use sr_primitives::traits::Hash as _;
 use substrate_primitives::storage::StorageKey;
 
-use radicle_registry_runtime::{
-    opaque::Block as OpaqueBlock, AccountId, Event, Hash, Hashing, Runtime,
-};
-use substrate_subxt::system::SystemStore as _;
+use radicle_registry_runtime::{opaque::Block as OpaqueBlock, Event, Hash, Hashing, Runtime};
 
 use crate::backend;
 use crate::interface::*;
@@ -89,16 +86,8 @@ impl backend::Backend for RemoteNode {
         }))
     }
 
-    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error> {
-        let genesis_hash = self.genesis_hash;
-        Box::new(
-            self.subxt_client
-                .account_nonce(account_id.clone())
-                .map(move |nonce| TransactionExtra {
-                    nonce,
-                    genesis_hash,
-                }),
-        )
+    fn get_genesis_hash(&self) -> Hash {
+        self.genesis_hash
     }
 }
 

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -42,9 +42,8 @@ impl backend::Backend for RemoteNodeWithExecutor {
         self.run_sync(move |backend| backend.fetch(key))
     }
 
-    /// Get transaction extra from current ledger state to create valid transactions.
-    fn get_transaction_extra(&self, account_id: &AccountId) -> Response<TransactionExtra, Error> {
-        self.run_sync(move |backend| backend.get_transaction_extra(account_id))
+    fn get_genesis_hash(&self) -> Hash {
+        self.backend.get_genesis_hash()
     }
 }
 

--- a/client/src/transaction.rs
+++ b/client/src/transaction.rs
@@ -1,8 +1,9 @@
-//! Build a signed extrinsic
+//! Provides [Transaction] and [TransactionExtra].
 use parity_scale_codec::Encode;
 use radicle_registry_runtime::UncheckedExtrinsic;
 use sr_primitives::generic::{Era, SignedPayload};
 use sr_primitives::traits::SignedExtension;
+use std::marker::PhantomData;
 
 pub use radicle_registry_runtime::{
     registry::{Project, ProjectId},
@@ -11,24 +12,60 @@ pub use radicle_registry_runtime::{
 pub use substrate_primitives::crypto::{Pair as CryptoPair, Public as CryptoPublic};
 pub use substrate_primitives::ed25519;
 
-pub use crate::interface::{Call, TransactionExtra};
+pub use crate::call::Call;
 pub use radicle_registry_runtime::{Call as RuntimeCall, Hash, Index, SignedExtra};
+
+#[derive(Clone, Debug)]
+/// Transaction the can be submitted to the blockchain.
+///
+/// A transaction includes
+/// * the author
+/// * the runtime call
+/// * extra data to like the gensis hash and account nonce
+/// * a valid signature
+///
+/// The transaction type is generic over the runtime call parameter which must implement [Call].
+///
+/// A transaction can be created with [Transaction::new_signed]. The necessary transaction data
+/// must be obtained from the client with [crate::ClientT::account_nonce] and [crate::ClientT::genesis_hash].
+pub struct Transaction<Call_: Call> {
+    _phantom_data: PhantomData<Call_>,
+    pub(crate) extrinsic: UncheckedExtrinsic,
+}
+
+impl<Call_: Call> Transaction<Call_> {
+    /// Create and sign a transaction for the given call.
+    pub fn new_signed(
+        signer: &ed25519::Pair,
+        call: Call_,
+        transaction_extra: TransactionExtra,
+    ) -> Self {
+        let extrinsic = signed_extrinsic(signer, call.into_runtime_call(), transaction_extra);
+        Transaction {
+            _phantom_data: PhantomData,
+            extrinsic,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+/// The data that is required from the blockchain state to create a valid transaction.
+pub struct TransactionExtra {
+    /// The nonce of the account that is the transaction author.
+    pub nonce: Index,
+    pub genesis_hash: Hash,
+}
 
 /// Return a properly signed [UncheckedExtrinsic] for the given parameters that passes all
 /// validation checks. See the `Checkable` implementation of [UncheckedExtrinsic] for how
 /// validation is performed.
 ///
 /// `genesis_hash` is the genesis hash of the block chain this intrinsic is valid for.
-pub fn signed_extrinsic(
+fn signed_extrinsic(
     signer: &ed25519::Pair,
     call: RuntimeCall,
-    nonce: Index,
-    genesis_hash: Hash,
+    extra: TransactionExtra,
 ) -> UncheckedExtrinsic {
-    let extra = TransactionExtra {
-        nonce,
-        genesis_hash,
-    };
     let (runtime_extra, additional_signed) = transaction_extra_to_runtime_extra(extra);
     let raw_payload = SignedPayload::from_raw(call, runtime_extra, additional_signed);
     let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
@@ -116,8 +153,10 @@ mod test {
         let xt = signed_extrinsic(
             &key_pair,
             paint_system::Call::fill_block().into(),
-            0,
-            genesis_hash,
+            TransactionExtra {
+                nonce: 0,
+                genesis_hash,
+            },
         );
 
         test_ext


### PR DESCRIPTION
To allow offline transaction signing we add the following APIs
* `Transaction` type that holds a signed transaction and is generic over the call. The type parameter is required to relate transactions to their result.
* `Transaction::new_signed()` constructor for offline signing.
* `ClientT::submit_signed` can submit a signed `Transaction`.
* `ClientT::account_nonce()` gets the account nonce from the chain state
* `ClientT::genesis_hash()` returns the genesis hash required to
  construct a transaction