### PR TITLE
Update substrate node to use GRANDPA finality logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "finality-grandpa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34754852da8d86bc509715292c73140a5b678656d0b16132acd6737bdb5fd5f8"
+dependencies = [
+ "futures 0.1.29",
+ "hashbrown 0.6.3",
+ "log 0.4.8",
+ "num-traits",
+ "parity-scale-codec",
+ "parking_lot 0.9.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +3664,8 @@ dependencies = [
  "substrate-consensus-aura",
  "substrate-consensus-aura-primitives",
  "substrate-executor",
+ "substrate-finality-grandpa",
+ "substrate-finality-grandpa-primitives",
  "substrate-inherents",
  "substrate-network",
  "substrate-primitives",
@@ -3667,6 +3683,7 @@ dependencies = [
  "paint-aura",
  "paint-balances",
  "paint-executive",
+ "paint-grandpa",
  "paint-randomness-collective-flip",
  "paint-sudo",
  "paint-support",
@@ -4894,6 +4911,36 @@ dependencies = [
  "primitive-types",
  "sr-std",
  "substrate-primitives-storage",
+]
+
+[[package]]
+name = "substrate-finality-grandpa"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?rev=dc4a8329b9c47790c25429a5df272b3648275c1b#dc4a8329b9c47790c25429a5df272b3648275c1b"
+dependencies = [
+ "finality-grandpa",
+ "fork-tree",
+ "futures 0.1.29",
+ "futures-preview",
+ "log 0.4.8",
+ "paint-finality-tracker",
+ "parity-scale-codec",
+ "parking_lot 0.9.0",
+ "rand 0.7.2",
+ "serde_json",
+ "sr-primitives",
+ "substrate-client",
+ "substrate-client-api",
+ "substrate-consensus-common",
+ "substrate-finality-grandpa-primitives",
+ "substrate-header-metadata",
+ "substrate-inherents",
+ "substrate-keystore",
+ "substrate-network",
+ "substrate-primitives",
+ "substrate-telemetry",
+ "tokio-executor",
+ "tokio-timer",
 ]
 
 [[package]]

--- a/ci/run
+++ b/ci/run
@@ -15,7 +15,7 @@ fi
 TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'
 
 echo "--- Load cache"
-declare -i cache_version=11
+declare -i cache_version=12
 target_cache=/cache/target-v${cache_version}
 target_cache_key_file="$target_cache/_key"
 cache_key="$(sha256sum Cargo.lock | cut -f 1 -d ' ')"

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -89,6 +89,7 @@ fn make_genesis_config() -> GenesisConfig {
             vesting: vec![],
         }),
         paint_sudo: None,
+        paint_grandpa: None,
         system: None,
     }
 }

--- a/client/src/transaction.rs
+++ b/client/src/transaction.rs
@@ -135,6 +135,7 @@ mod test {
             paint_balances: None,
             paint_sudo: None,
             system: None,
+            paint_grandpa: None,
         };
         let mut test_ext = sr_io::TestExternalities::new(genesis_config.build_storage().unwrap());
         let (key_pair, _) = ed25519::Pair::generate();

--- a/local-devnet/README.md
+++ b/local-devnet/README.md
@@ -12,7 +12,7 @@ Then you can start the network with `docker-compose up`
 ### Overview
 
 * Devnet consists of three authority nodes running Aura.
-* Grandpa (for finalization) is currently not enabled
+* Grandpa (for finalization) is currently enabled.
 * Chain data of nodes is persisted in Docker volumes.
 * We expose the RPC API of the first node on the standard RPC API port.
 * See `local_devnet()` for chain spec in `../node/src/chain_spec.rs`.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -78,3 +78,11 @@ rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 git = "https://github.com/paritytech/substrate"
 rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 package = "substrate-transaction-pool"
+
+[dependencies.substrate-finality-grandpa]
+git = "https://github.com/paritytech/substrate"
+rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
+
+[dependencies.substrate-finality-grandpa-primitives]
+git = "https://github.com/paritytech/substrate"
+rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -6,8 +6,10 @@
 use aura_primitives::sr25519::AuthorityId as AuraId;
 use primitives::{Pair, Public};
 use radicle_registry_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, SudoConfig, SystemConfig, WASM_BINARY,
+    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SudoConfig, SystemConfig,
+    WASM_BINARY,
 };
+use substrate_finality_grandpa_primitives::AuthorityId as GrandpaId;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = substrate_service::ChainSpec<GenesisConfig>;
@@ -43,7 +45,8 @@ fn dev_genesis_config() -> GenesisConfig {
         get_from_seed::<AccountId>("Alice//stash"),
         get_from_seed::<AccountId>("Bob//stash"),
     ];
-    let authorities = vec![get_from_seed::<AuraId>("Alice")];
+    let aura_authorities = vec![get_from_seed::<AuraId>("Alice")];
+    let grandpa_authorities = vec![(get_from_seed::<GrandpaId>("Alice"), 1)];
     let root_key = get_from_seed::<AccountId>("Alice");
     GenesisConfig {
         system: Some(SystemConfig {
@@ -59,7 +62,12 @@ fn dev_genesis_config() -> GenesisConfig {
             vesting: vec![],
         }),
         paint_sudo: Some(SudoConfig { key: root_key }),
-        paint_aura: Some(AuraConfig { authorities }),
+        paint_aura: Some(AuraConfig {
+            authorities: aura_authorities,
+        }),
+        paint_grandpa: Some(GrandpaConfig {
+            authorities: grandpa_authorities,
+        }),
     }
 }
 
@@ -84,10 +92,15 @@ fn local_dev_genesis_config() -> GenesisConfig {
         get_from_seed::<AccountId>("Alice//stash"),
         get_from_seed::<AccountId>("Bob//stash"),
     ];
-    let authorities = vec![
+    let aura_authorities = vec![
         get_from_seed::<AuraId>("Alice"),
         get_from_seed::<AuraId>("Bob"),
         get_from_seed::<AuraId>("Charlie"),
+    ];
+    let grandpa_authorities = vec![
+        (get_from_seed::<GrandpaId>("Alice"), 1),
+        (get_from_seed::<GrandpaId>("Bob"), 1),
+        (get_from_seed::<GrandpaId>("Charlie"), 1),
     ];
     let root_key = get_from_seed::<AccountId>("Alice");
     GenesisConfig {
@@ -104,7 +117,12 @@ fn local_dev_genesis_config() -> GenesisConfig {
             vesting: vec![],
         }),
         paint_sudo: Some(SudoConfig { key: root_key }),
-        paint_aura: Some(AuraConfig { authorities }),
+        paint_aura: Some(AuraConfig {
+            authorities: aura_authorities,
+        }),
+        paint_grandpa: Some(GrandpaConfig {
+            authorities: grandpa_authorities,
+        }),
     }
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 default = ["std"]
 std = [
     "codec/std",
+    "paint-grandpa/std",
     "serde",
     "sr-primitives/std",
     "sr-io/std",
@@ -147,6 +148,12 @@ default_features = false
 git = "https://github.com/paritytech/substrate"
 rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 default_features = false
+
+[dependencies.paint-grandpa]
+git = "https://github.com/paritytech/substrate"
+rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
+default_features = false
+package = "paint-grandpa"
 
 [build-dependencies]
 substrate-wasm-builder-runner = "1.0.2"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,8 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 extern crate alloc;
 
+use paint_grandpa::fg_primitives;
+use paint_grandpa::AuthorityList as GrandpaAuthorityList;
 use paint_support::{construct_runtime, parameter_types, traits::Randomness};
 use sr_primitives::traits::{BlakeTwo256, Block as BlockT, ConvertInto, NumberFor};
 use sr_primitives::weights::Weight;
@@ -88,6 +90,7 @@ pub mod opaque {
     impl_opaque_keys! {
         pub struct SessionKeys {
             pub aura: Aura,
+            pub grandpa: Grandpa,
         }
     }
 }
@@ -153,6 +156,10 @@ impl paint_system::Trait for Runtime {
 
 impl paint_aura::Trait for Runtime {
     type AuthorityId = AuraId;
+}
+
+impl paint_grandpa::Trait for Runtime {
+    type Event = Event;
 }
 
 parameter_types! {
@@ -221,6 +228,7 @@ construct_runtime!(
                 Timestamp: paint_timestamp::{Module, Call, Storage, Inherent},
                 RandomnessCollectiveFlip: paint_randomness_collective_flip::{Module, Storage},
                 Aura: paint_aura::{Module, Config<T>, Inherent(Timestamp)},
+                Grandpa: paint_grandpa::{Module, Call, Storage, Config, Event},
                 Balances: paint_balances::{default, Error},
                 Sudo: paint_sudo,
                 Registry: registry::{Module, Call, Storage, Event},
@@ -328,6 +336,12 @@ impl_runtime_apis! {
     impl substrate_session::SessionKeys<Block> for Runtime {
         fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
             opaque::SessionKeys::generate(seed)
+        }
+    }
+
+    impl fg_primitives::GrandpaApi<Block> for Runtime {
+        fn grandpa_authorities() -> GrandpaAuthorityList {
+            Grandpa::grandpa_authorities()
         }
     }
 }


### PR DESCRIPTION
Previously, the `radicle-registry` node did not use the GRANDPA finality logic that is present in the [node template](https://github.com/paritytech/substrate/blob/40a16efefc070faf5a25442bc3ae1d0ea2478eee/bin/node-template/src/service.rs#L79) from Substrate it was adapted from.

This PR enables this functionality.