### PR TITLE
Always update cache on branch builds

### DIFF
--- a/ci/run
+++ b/ci/run
@@ -76,10 +76,10 @@ rm -rf \
   target/*/wbuild/target/*/incremental \
   target/*/wbuild-runner/target/*/incremental
 
-if [[ ! -d "$target_cache" ]]; then
+if [[ -d "$target_cache" && "$BUILDKITE_BRANCH" == "master" ]]; then
+  echo "Cache $target_cache does already exist"
+else
   time cp -aTu target "$target_cache"
   echo "$cache_key" > "$target_cache_key_file"
   echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
-else
-  echo "Cache $target_cache does already exist"
 fi


### PR DESCRIPTION
We always update the cache on branch builds to make subsequent builds
faster. This means that the cache for branch builds will always grow but
this is ok because branches are short lived.