### PR TITLE
Use async/.await for backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
+dependencies = [
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.11",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,6 +3636,7 @@ dependencies = [
 name = "radicle-registry-client"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "env_logger 0.7.1",
  "futures 0.1.29",
  "futures 0.3.1",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,6 +15,7 @@ futures03 = { package = "futures", version = "0.3", features = ["compat"] }
 log = "0.4"
 parity-scale-codec = "1.0"
 tokio = "0.1"
+async-trait = "0.1"
 
 [dependencies.paint-system]
 git = "https://github.com/paritytech/substrate"

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -1,4 +1,4 @@
-use futures01::future::Future;
+//! Offline signing and creation of a `Transfer` transaction.
 use futures03::compat::{Compat, Future01CompatExt};
 use futures03::future::FutureExt;
 
@@ -11,7 +11,6 @@ fn main() {
     env_logger::init();
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(Compat::new(go().boxed())).unwrap();
-    runtime.shutdown_now().wait().unwrap();
 }
 
 async fn go() -> Result<(), Error> {

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -41,13 +41,14 @@ pub struct TransactionApplied {
 ///
 /// The interface is low-level and mostly agnostic of the runtime code. Transaction extra data and
 /// event information from the runtime marks an exception
+#[async_trait::async_trait]
 pub trait Backend {
     /// Submit a signed transaction to the ledger and return when it has been applied and included
     /// in a block.
-    fn submit(&self, xt: UncheckedExtrinsic) -> Response<TransactionApplied, Error>;
+    async fn submit(&self, xt: UncheckedExtrinsic) -> Result<TransactionApplied, Error>;
 
     /// Fetch a value from the runtime state storage.
-    fn fetch(&self, key: &[u8]) -> Response<Option<Vec<u8>>, Error>;
+    async fn fetch(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error>;
 
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;

--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -3,5 +3,5 @@
 set -euo pipefail
 
 export RUST_LOG="${RUST_LOG:-info},substrate_consensus_slots=error,substrate=error"
-radicle-registry-node=./target/release/radicle-registry-node
-exec $radicle-registry-node "$@" --dev
+radicle_registry_node=./target/release/radicle-registry-node
+exec $radicle_registry_node "$@" --dev


### PR DESCRIPTION
We use `async`/`.await` and `futures` v0.3 for all the backends.