### PR TITLE
ci: Upload node binary to bintray on builds

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,8 +2,7 @@ steps:
   - label: "Check formatting, lint, build and test "
     command: 'ci/run'
     env:
-      DOCKER_IMAGE: gcr.io/opensourcecoin/radicle-registry@sha256:14f86dacda303f96b14cb1e41dc2e54be70f89ee6917920dd58207239a405f17
-      DOCKER_FILE: ci/base-image/Dockerfile
+      DOCKER_IMAGE: gcr.io/opensourcecoin/radicle-registry/ci-base@sha256:43990b4482544a2056cb61409d7e3171e4b67a2418323eab2fbd0844cad0c29c
       STEP_DOCKER_FILE: ci/node-image/Dockerfile
       STEP_DOCKER_IMAGE: gcr.io/opensourcecoin/radicle-registry/node
     agents:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -117,8 +117,8 @@ After performing the necessary changes to the Dockerfile located in
 repository and run the following:
 
 ```bash
-docker build ci/base-image --tag gcr.io/opensourcecoin/radicle-registry
-docker push gcr.io/opensourcecoin/radicle-registry
+docker build ci/base-image --tag gcr.io/opensourcecoin/radicle-registry/ci-base
+docker push gcr.io/opensourcecoin/radicle-registry/ci-base
 ```
 
 The `docker push` command outputs the pushed image’s digest. To use the pushed

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ You can find examples in the `./client/examples` directory.
 Getting and Running the Node
 ----------------------------
 
-We build binaries of the node and docker images for every master commit.
+We build binaries of the node and docker images for every pushed commit.
 
-The node binaries are available for the `x86_64-uknown-linux-gnu` target triple.
-They are provided as artifacts by our CI. You can find the through the
-[Buildkite UI][buildkite-master].
+Node binaries are available for the `x86_64-unknown-linux-gnu` target triple.
+You can download them from
+```
+https://dl.bintray.com/oscoin/radicle-registry-files/git-<COMMIT_SHA>/x86_64-linux-gnu/radicle-registry-node
+```
 
 You can pull a docker image of the node with
 ```bash

--- a/ci/base-image/Dockerfile
+++ b/ci/base-image/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
         llvm-dev \
         make \
         pkg-config \
-        wget \
+        curl \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
@@ -38,7 +38,7 @@ RUN apt-get update \
 RUN set -euxo pipefail; \
     sccache_version=0.2.12; \
     sccache_base=sccache-$sccache_version-x86_64-unknown-linux-musl; \
-    wget --quiet https://github.com/mozilla/sccache/releases/download/$sccache_version/$sccache_base.tar.gz; \
+    curl -sSLO https://github.com/mozilla/sccache/releases/download/$sccache_version/$sccache_base.tar.gz; \
     echo "26fd04c1273952cc2a0f359a71c8a1857137f0ee3634058b3f4a63b69fc8eb7f  $sccache_base.tar.gz" | sha256sum -c -; \
     tar -zxf "$sccache_base.tar.gz"; \
     mv "$sccache_base/sccache" /usr/local/bin/sccache; \
@@ -56,7 +56,7 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.20.2/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -sSLO "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \

--- a/ci/run
+++ b/ci/run
@@ -15,7 +15,7 @@ fi
 TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'
 
 echo "--- Load cache"
-declare -i cache_version=13
+declare -i cache_version=14
 target_cache=/cache/target-v${cache_version}
 target_cache_key_file="$target_cache/_key"
 cache_key="$(sha256sum Cargo.lock | cut -f 1 -d ' ')"
@@ -86,4 +86,41 @@ else
   time cp -aTu target "$target_cache"
   echo "$cache_key" > "$target_cache_key_file"
   echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
+fi
+
+# Upload the node binary to bintray using the commit hash as the version.
+function upload_to_bintray () {
+  local -r api_url="https://bintray.com/api/v1"
+  local -r subject="oscoin"
+  local -r repo="radicle-registry-files"
+  local -r package="radicle-registy-node"
+  local -r version="git-$BUILDKITE_COMMIT"
+  local -r target_triple="x86_64-linux-gnu"
+  local -r remote_file="$version/$target_triple/radicle-registry-node"
+  local -r local_file="./artifacts/radicle-registry-node"
+  local -r user="monadic-ci"
+
+  local file_checksum
+  file_checksum="$(sha256sum "$local_file" | cut -f1 -d ' ')"
+
+  curl \
+    --show-error \
+    -X PUT \
+    --basic --user "$user:$BINTRAY_API_KEY" \
+    -H "X-Bintray-Package: $package" \
+    -H "X-Bintray-Version: $version" \
+    -H "X-Bintray-Publish: 1" \
+    -H "X-Checksum-Sha2: $file_checksum" \
+    "$api_url/content/$subject/$repo/$remote_file?publish=1" \
+    --data-binary @$local_file
+  # Response from curl does not end with new line
+  echo
+
+  local -r download_path="https://dl.bintray.com/$subject/$repo/$remote_file"
+  echo "Node binary available from $download_path"
+}
+
+if [[ -n "${BINTRAY_API_KEY:-}" ]]; then
+  echo "--- Upload bintray artifacts"
+  upload_to_bintray
 fi


### PR DESCRIPTION
We upload the node binaries to bintray on every build. The download URL is documented in the README