### PR TITLE
Revamped CI caching

### DIFF
--- a/ci/run
+++ b/ci/run
@@ -14,34 +14,16 @@ fi
 
 TIMEFORMAT='elapsed time: %R (user: %U, system: %S)'
 
-echo "--- Load cache"
-declare -i cache_version=14
-target_cache=/cache/target-v${cache_version}
-target_cache_key_file="$target_cache/_key"
-cache_key="$(sha256sum Cargo.lock | cut -f 1 -d ' ')"
+declare -r target_cache="/cache/target"
 
-if [[ $BUILDKITE_BRANCH = "master" ]]; then
-  declare -i old_cache_version="$cache_version - 1"
-  old_target_cache=/cache/target-v${old_cache_version}
-  if [[ -d "$old_target_cache" ]]; then
-    rm -rf "$old_target_cache"
-    echo "Deleted old cache $old_target_cache"
-  fi
-fi
+# Incremental builds use timestamps of local code. Since we always
+# check it out fresh we can never use incremental builds.
+export CARGO_BUILD_INCREMENTAL=false
 
-if [[ -d "$target_cache" ]]; then
-  if [[ -f "$target_cache_key_file" ]]; then
-    if [[ "$(cat $target_cache_key_file)" != "$cache_key" ]]; then
-      echo "Error: Target cache key does not match project cache key."
-      echo "Please update the cache version in ./ci/run"
-      exit 1
-    fi
-  fi
-  time cp -aT "$target_cache" target
-  echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
-else
-  echo "Cache $target_cache not available"
-fi
+echo "--- Link target dir to cache"
+mkdir -p "$target_cache"
+ln -s "$target_cache" ./target
+echo "Size of ./target is $(du -Dsh "./target" | cut -f 1)"
 
 echo "--- scripts/check-license-headers"
 time ./scripts/check-license-headers
@@ -66,27 +48,15 @@ registry_node_pid=$!
 cargo test --all --release --color=always
 kill "$registry_node_pid"
 
-echo "--- Save cache"
-# Remove large build artifacts that are faster to build than cache.
-# The `target/release/radicle-registry-node` file is kept because they
-# are uploaded to Buildkite (i.e. the node).
-# The folder and its contents are deleted at a later step in the build.
+echo "--- Copy artifacts"
 mkdir artifacts
 cp -a target/release/radicle-registry-node artifacts
 cp -a target/release/radicle-registry-node ci/node-image
-rm -rf \
-  target/*/radicle-registry-node* \
-  target/*/incremental \
-  target/*/wbuild/target/*/incremental \
-  target/*/wbuild-runner/target/*/incremental
 
-if [[ -d "$target_cache" && "$BUILDKITE_BRANCH" == "master" ]]; then
-  echo "Cache $target_cache does already exist"
-else
-  time cp -aTu target "$target_cache"
-  echo "$cache_key" > "$target_cache_key_file"
-  echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
-fi
+echo "--- Cleanup cache"
+# Remove all executables that need to be rebuild.
+find ./target -maxdepth 2 -executable -type f -exec rm {} \;
+echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
 
 # Upload the node binary to bintray using the commit hash as the version.
 function upload_to_bintray () {


### PR DESCRIPTION
We rewrote the caching logic for CI. The caching behavior is the same but now we don’t need to manually update the cache version and clean the cache.