### PR TITLE
Repeatable end-to-end tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures01"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef8cbbf52909170053540c6c05a62433ddb60662dabee714e2a882caa864f22"
+dependencies = [
+ "futures 0.1.29",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3646,6 +3655,7 @@ dependencies = [
  "paint-transaction-payment",
  "parity-scale-codec",
  "radicle-registry-runtime",
+ "rand 0.7.2",
  "sr-io",
  "sr-primitives",
  "substrate-primitives",
@@ -3687,7 +3697,7 @@ dependencies = [
 name = "radicle-registry-runtime"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.29",
+ "futures01",
  "paint-aura",
  "paint-balances",
  "paint-executive",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -40,3 +40,6 @@ rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 [dependencies.sr-io]
 git = "https://github.com/paritytech/substrate"
 rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
+
+[dev-dependencies]
+rand = "0.7.2"

--- a/client/tests/common/mod.rs
+++ b/client/tests/common/mod.rs
@@ -1,0 +1,2 @@
+// TODO Very poor man’s code sharing. This should be moved into a shared package
+include!("../../../runtime/tests/common/mod.rs");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -160,6 +160,6 @@ package = "paint-grandpa"
 substrate-wasm-builder-runner = "1.0.2"
 
 [dev-dependencies]
-futures = "0.1"
+futures01 = "0.1"
 rand = "0.7.2"
 radicle-registry-client = { path = "../client" }

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -4,7 +4,7 @@
 ///
 /// The tests in this module concern checkpoint creation and setting project
 /// checkpoints.
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use radicle_registry_client::*;
 

--- a/runtime/tests/checkpoint_creation.rs
+++ b/runtime/tests/checkpoint_creation.rs
@@ -3,7 +3,7 @@
 /// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
 ///
 /// The tests in this module concern checkpoint creation.
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use radicle_registry_client::*;
 

--- a/runtime/tests/common/mod.rs
+++ b/runtime/tests/common/mod.rs
@@ -1,5 +1,5 @@
 /// Miscellaneous helpers used throughout other tests.
-use futures::prelude::*;
+use futures01::prelude::*;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -3,7 +3,7 @@
 /// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
 ///
 /// The tests in this module concern project registration.
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use radicle_registry_client::*;
 

--- a/runtime/tests/transfer.rs
+++ b/runtime/tests/transfer.rs
@@ -3,7 +3,7 @@
 /// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
 ///
 /// The tests in this module concern transferring funds.
-use futures::prelude::*;
+use futures01::prelude::*;
 
 use radicle_registry_client::*;
 


### PR DESCRIPTION
Before, end-to-end test could only be run once since we were always using the same project ID. Now we generate a random project ID.

This change also includes a renaming of the `futures` crate to `futures01` for the runtime tests.