### PR TITLE
Move subxt code into RemoteBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3660,6 +3660,7 @@ dependencies = [
  "sr-primitives",
  "substrate-primitives",
  "substrate-subxt",
+ "substrate-transaction-graph",
  "tokio",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -41,5 +41,9 @@ rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 git = "https://github.com/paritytech/substrate"
 rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
 
+[dependencies.substrate-transaction-graph]
+git = "https://github.com/paritytech/substrate"
+rev = "dc4a8329b9c47790c25429a5df272b3648275c1b"
+
 [dev-dependencies]
 rand = "0.7.2"

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -77,7 +77,15 @@ impl backend::Backend for Emulator {
         })
     }
 
-    async fn fetch(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    async fn fetch(
+        &self,
+        key: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        if block_hash.is_some() {
+            panic!("Passing a block hash 'fetch' for the client emulator is not supported")
+        }
+
         let test_ext = &mut self.test_ext.lock().unwrap();
         let maybe_data = test_ext.execute_with(|| sr_io::storage::get(key));
         Ok(maybe_data)

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -47,8 +47,12 @@ pub trait Backend {
     /// in a block.
     async fn submit(&self, xt: UncheckedExtrinsic) -> Result<TransactionApplied, Error>;
 
-    /// Fetch a value from the runtime state storage.
-    async fn fetch(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error>;
+    /// Fetch a value from the runtime state storage at the given block.
+    async fn fetch(
+        &self,
+        key: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<Vec<u8>>, Error>;
 
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -82,10 +82,14 @@ impl backend::Backend for RemoteNode {
         })
     }
 
-    async fn fetch(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    async fn fetch(
+        &self,
+        key: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<Vec<u8>>, Error> {
         let key = StorageKey(Vec::from(key));
         let rpc = self.subxt_client.connect().compat().await?;
-        let maybe_data = rpc.state.storage(key, None).compat().await?;
+        let maybe_data = rpc.state.storage(key, block_hash).compat().await?;
         Ok(maybe_data.map(|data| data.0))
     }
 

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -14,13 +14,19 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! [backend::Backend] implementation for a remote full node
-use futures03::compat::Future01CompatExt as _;
+use futures01::prelude::Stream as _;
+use futures03::compat::{Future01CompatExt as _, Stream01CompatExt as _};
+use futures03::prelude::*;
+use parity_scale_codec::{Decode, Encode as _};
 use sr_primitives::traits::Hash as _;
-use substrate_primitives::storage::StorageKey;
+use substrate_primitives::{storage::StorageKey, twox_128};
+use substrate_transaction_graph::watcher::Status as TxStatus;
 
-use radicle_registry_runtime::{opaque::Block as OpaqueBlock, Event, Hash, Hashing, Runtime};
+use radicle_registry_runtime::{
+    opaque::Block as OpaqueBlock, Event, EventRecord, Hash, Hashing, Runtime,
+};
 
-use crate::backend;
+use crate::backend::{self, Backend};
 use crate::interface::*;
 
 #[derive(Clone)]
@@ -28,8 +34,6 @@ pub struct RemoteNode {
     subxt_client: substrate_subxt::Client<Runtime>,
     genesis_hash: Hash,
 }
-
-type ExtrinsicSuccess = substrate_subxt::ExtrinsicSuccess<Runtime>;
 
 impl RemoteNode {
     pub async fn create() -> Result<Self, Error> {
@@ -45,22 +49,60 @@ impl RemoteNode {
         })
     }
 
-    /// Returns the list of events dispatched by the extrinsic.
-    ///
-    /// [ExtrinsicSuccess] contains the extrinsic hash and the list of all events in the block.
-    /// From this list we return only those events that were dispatched by the extinsic.
-    ///
-    /// Requires an API call to get the block
-    async fn extract_events(&self, ext_success: ExtrinsicSuccess) -> Result<Vec<Event>, Error> {
-        let maybe_signed_block = self
-            .subxt_client
-            .block(Some(ext_success.block))
+    /// Submit a transaction and return the block hash once it is included in a block.
+    async fn submit_transaction(
+        &self,
+        xt: backend::UncheckedExtrinsic,
+    ) -> Result<BlockHash, Error> {
+        let rpc = self.subxt_client.connect().compat().await?;
+
+        let tx_status_stream = rpc
+            .author
+            .watch_extrinsic(xt.encode().into())
             .compat()
             .await?;
-        let block = maybe_signed_block.unwrap().block;
-        // TODO panic and explain
-        extract_events(block, ext_success)
-            .ok_or_else(|| Error::from("Extrinsic not found in block"))
+
+        let mut tx_status_stream = tx_status_stream.map_err(Error::from).compat();
+
+        loop {
+            let opt_tx_status = tx_status_stream.try_next().await?;
+            match opt_tx_status {
+                None => return Err(Error::from("watch_extrinsic stream terminated")),
+                Some(tx_status) => match tx_status {
+                    TxStatus::Future | TxStatus::Ready | TxStatus::Broadcast(_) => continue,
+                    TxStatus::Finalized(block_hash) => return Ok(block_hash),
+                    TxStatus::Usurped(_) => return Err("Extrinsic Usurped".into()),
+                    TxStatus::Dropped => return Err("Extrinsic Dropped".into()),
+                    TxStatus::Invalid => return Err("Extrinsic Invalid".into()),
+                },
+            }
+        }
+    }
+
+    /// Return all the events belonging to the transaction included in the given block.
+    ///
+    /// This requires the transaction to be included in the given block.
+    async fn get_transaction_events(
+        &self,
+        tx_hash: TxHash,
+        block_hash: BlockHash,
+    ) -> Result<Vec<Event>, Error> {
+        let events_key = b"System Events";
+        let storage_key = twox_128(events_key);
+        let events_data = self
+            .fetch(&storage_key[..], Some(block_hash))
+            .await?
+            .unwrap_or_default();
+        let event_records: Vec<radicle_registry_runtime::EventRecord> =
+            Decode::decode(&mut &events_data[..]).map_err(Error::Codec)?;
+
+        let rpc = self.subxt_client.connect().compat().await?;
+        let opt_signed_block = rpc.chain.block(Some(block_hash)).compat().await?;
+        let block = opt_signed_block
+            .expect("Block that should include submitted transaction does not exist")
+            .block;
+        Ok(extract_transaction_events(tx_hash, block, event_records)
+            .expect("Failed to extract transaction events"))
     }
 }
 
@@ -68,16 +110,14 @@ impl RemoteNode {
 impl backend::Backend for RemoteNode {
     async fn submit(
         &self,
-        extrinsic: backend::UncheckedExtrinsic,
+        xt: backend::UncheckedExtrinsic,
     ) -> Result<backend::TransactionApplied, Error> {
-        let rpc = self.subxt_client.connect().compat().await?;
-        let ext_success = rpc.submit_and_watch_extrinsic(extrinsic).compat().await?;
-        let tx_hash = ext_success.extrinsic;
-        let block = ext_success.block;
-        let events = self.extract_events(ext_success).await?;
+        let tx_hash = Hashing::hash_of(&xt);
+        let block_hash = self.submit_transaction(xt).await?;
+        let events = self.get_transaction_events(tx_hash, block_hash).await?;
         Ok(backend::TransactionApplied {
             tx_hash,
-            block,
+            block: block_hash,
             events,
         })
     }
@@ -98,29 +138,35 @@ impl backend::Backend for RemoteNode {
     }
 }
 
-/// Given an [ExtrinsicSuccess] struct for a transaction and the block the includes the transaction
-/// return all the events belonging to the transaction.
+/// Return all the events belonging to the transaction included in the given block.
+///
+/// The following conditions must hold:
+/// * The transaction with `tx_hash` must be included in `block`.
+/// * `event_records` are the events deposited by the runtime when `block` was executed.
 ///
 /// Returns `None` if no events for the transaction were found. This should be treated as an error
 /// since the events should at least include the system event for the transaction.
-fn extract_events(block: OpaqueBlock, ext_success: ExtrinsicSuccess) -> Option<Vec<Event>> {
+fn extract_transaction_events(
+    tx_hash: TxHash,
+    block: OpaqueBlock,
+    event_records: Vec<EventRecord>,
+) -> Option<Vec<Event>> {
     let xt_index = block
         .extrinsics
         .iter()
         .enumerate()
         .find_map(|(index, tx)| {
-            if Hashing::hash_of(tx) == ext_success.extrinsic {
+            if Hashing::hash_of(tx) == tx_hash {
                 Some(index)
             } else {
                 None
             }
         })?;
-    let events = ext_success
-        .events
-        .iter()
+    let events = event_records
+        .into_iter()
         .filter_map(|event_record| match event_record.phase {
             paint_system::Phase::ApplyExtrinsic(i) if i == xt_index as u32 => {
-                Some(event_record.event.clone())
+                Some(event_record.event)
             }
             _ => None,
         })

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -56,11 +56,15 @@ impl backend::Backend for RemoteNodeWithExecutor {
         handle.await
     }
 
-    async fn fetch(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    async fn fetch(
+        &self,
+        key: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<Vec<u8>>, Error> {
         let backend = self.backend.clone();
         let key = Vec::from(key);
         let handle = Executor01CompatExt::compat(self.runtime.executor())
-            .spawn_with_handle(async move { backend.fetch(&key).await })
+            .spawn_with_handle(async move { backend.fetch(&key, block_hash).await })
             .unwrap();
         handle.await
     }

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -38,8 +38,12 @@ pub use crate::transaction::{Transaction, TransactionExtra};
 #[doc(inline)]
 pub type Error = substrate_subxt::Error;
 
+/// The hash of a block. Uniquely identifies a transaction.
 #[doc(inline)]
+pub type BlockHash = Hash;
+
 /// The hash of a transaction. Uniquely identifies a transaction.
+#[doc(inline)]
 pub type TxHash = Hash;
 
 #[derive(Clone, Debug)]

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -38,7 +38,7 @@ pub use crate::transaction::{Transaction, TransactionExtra};
 #[doc(inline)]
 pub type Error = substrate_subxt::Error;
 
-/// The hash of a block. Uniquely identifies a transaction.
+/// The hash of a block. Uniquely identifies a block.
 #[doc(inline)]
 pub type BlockHash = Hash;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -107,7 +107,9 @@ impl Client {
     {
         let backend = self.backend.clone();
         future03_compat(async move {
-            let maybe_data = backend.fetch(S::storage_value_final_key().as_ref()).await?;
+            let maybe_data = backend
+                .fetch(S::storage_value_final_key().as_ref(), None)
+                .await?;
             let value = match maybe_data {
                 Some(data) => {
                     let value = Decode::decode(&mut &data[..])?;
@@ -142,7 +144,7 @@ impl Client {
         let key = S::storage_map_final_key(key);
         let key = Vec::from(key.as_ref());
         future03_compat(async move {
-            let maybe_data = backend.fetch(&key).await?;
+            let maybe_data = backend.fetch(&key, None).await?;
             let value = match maybe_data {
                 Some(data) => {
                     let value = Decode::decode(&mut &data[..])?;

--- a/subxt/src/rpc.rs
+++ b/subxt/src/rpc.rs
@@ -55,8 +55,8 @@ pub type BlockNumber<T> = NumberOrHex<<T as System>::BlockNumber>;
 /// Client for substrate rpc interfaces
 pub struct Rpc<T: System> {
     pub state: StateClient<T::Hash>,
-    chain: ChainClient<T::BlockNumber, T::Hash, T::Header, ChainBlock<T>>,
-    author: AuthorClient<T::Hash, T::Hash>,
+    pub chain: ChainClient<T::BlockNumber, T::Hash, T::Header, ChainBlock<T>>,
+    pub author: AuthorClient<T::Hash, T::Hash>,
 }
 
 /// Allows connecting to all inner interfaces on the same RpcChannel


### PR DESCRIPTION
We implement `RemoteNode::submit` with our own code instead of relying so much on `subxt` code.

This will enable us to ditch `substrate-subxt` and provides the necessary code to implement the transaction signing utilities.