### PR TITLE
Replace `cargo --all` invocations with `cargo --workspace`

### DIFF
--- a/ci/run
+++ b/ci/run
@@ -34,7 +34,7 @@ time cargo fmt --all -- --check
 echo "--- cargo build"
 export BUILD_DUMMY_WASM_BINARY=0
 export RUSTFLAGS="-D warnings"
-cargo build --all --all-targets --release
+cargo build --workspace --all-targets --release
 
 echo "--- cargo test"
 echo "Starting radicle-registry-node"
@@ -45,7 +45,7 @@ RUST_LOG=error ./target/release/radicle-registry-node \
 registry_node_pid=$!
 # We build tests in release mode so that we can reuse the artifacts
 # from 'cargo build'
-cargo test --all --release --color=always
+cargo test --workspace --release --color=always
 kill "$registry_node_pid"
 
 echo "--- Copy artifacts"


### PR DESCRIPTION
In the `cargo` tool, the `--all` flag has been deprecated for `--workspace`.