### PR TITLE
Prepare package metadata for crate publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,12 +3253,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "radicle-registry"
-version = "0.1.0"
-
-[[package]]
 name = "radicle-registry-cli"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "futures 0.1.29",
  "pretty_env_logger",
@@ -3268,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-client"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -3295,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-node"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ctrlc",
  "derive_more",
@@ -3325,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "radicle-registry-runtime"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "futures01",
  "paint-aura",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,3 @@
-[package]
-name = "radicle-registry"
-version = "0.1.0"
-authors = ["Monadic GmbH <radicle@monadic.xyz>"]
-edition = "2018"
-license = "GPL-3.0-only"
-
-[dependencies]
-
 [workspace]
 members = [
   "cli",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-name = "radicle-registry-cli"
-version = "0.1.0"
-authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
+name = "radicle-registry-cli"
+description = "CLI tools for interacting with the Radicle Registry"
+version = "0.0.0"
+authors = ["Monadic GmbH <radicle@monadic.xyz>"]
+homepage = "https://github.com/radicle-dev/radicle-registry"
+documentation = "https://github.com/radicle-dev/radicle-registry"
 license = "GPL-3.0-only"
+repository = "https://github.com/radicle-dev/radicle-registry"
 
 [dependencies]
 radicle-registry-client = { path = "../client" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
-name = "radicle-registry-client"
-version = "0.1.0"
-authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
+name = "radicle-registry-client"
+description = "Client library to interact with Radicle Registry node"
+version = "0.0.0"
+authors = ["Monadic GmbH <radicle@monadic.xyz>"]
+homepage = "https://github.com/radicle-dev/radicle-registry"
+documentation = "https://github.com/radicle-dev/radicle-registry"
 license = "GPL-3.0-only"
+repository = "https://github.com/radicle-dev/radicle-registry"
 
 [dependencies]
-radicle-registry-runtime = { path = "../runtime" }
+radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
 
 async-trait = "0.1"
 derive_more = "0.15"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
-name = "radicle-registry-node"
-authors = ["Monadic GmbH <radicle@monadic.xyz>"]
 edition = "2018"
-version = "0.1.0"
+name = "radicle-registry-node"
+description = "Full node for the Radicle Registry network"
+authors = ["Monadic GmbH <radicle@monadic.xyz>"]
+version = "0.0.0"
 license = "GPL-3.0-only"
+homepage = "https://github.com/radicle-dev/radicle-registry"
+documentation = "https://github.com/radicle-dev/radicle-registry"
+repository = "https://github.com/radicle-dev/radicle-registry"
 
 [dependencies]
+radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
+
 derive_more = "0.15.0"
 exit-future = "0.1.4"
 futures = "0.1.29"
@@ -21,9 +27,6 @@ version = "1.0.0"
 [dependencies.ctrlc]
 features = ["termination"]
 version = "3.1.3"
-
-[dependencies.radicle-registry-runtime]
-path = "../runtime"
 
 [dependencies.aura]
 git = "https://github.com/paritytech/substrate"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-name = "radicle-registry-runtime"
-authors = ["Monadic GmbH <radicle@monadic.xyz>"]
 edition = "2018"
-version = "0.1.0"
+name = "radicle-registry-runtime"
+description = "Substrate chain runtime for the Radicle Registry"
+authors = ["Monadic GmbH <radicle@monadic.xyz>"]
+version = "0.0.0"
+homepage = "https://github.com/radicle-dev/radicle-registry"
+documentation = "https://github.com/radicle-dev/radicle-registry"
 license = "GPL-3.0-only"
+repository = "https://github.com/radicle-dev/radicle-registry"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
We update the `Cargo.toml` files so the packages are ready for publishing.

We also remove the `[package]` section from the workspace root. It is not needed.