### PR TITLE
Separate transaction submission results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Upcoming
 
 ### Breaking changes
 
+* `Client::submit` and  `Client::submit_transaction` now return a wrapped
+  future. This allows consumers to distinguish the accepted and applied states
+  of a transaction.
 * Remove convenience methods for submitting transactions from the client
   - `Client::transfer`
   - `Client::register_project`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -70,6 +70,8 @@ fn run(args: Args) {
                 )
                 .wait()
                 .unwrap()
+                .wait()
+                .unwrap()
                 .result
                 .unwrap();
             let project_id = (name, domain);
@@ -83,6 +85,8 @@ fn run(args: Args) {
                         checkpoint_id,
                     },
                 )
+                .wait()
+                .unwrap()
                 .wait()
                 .unwrap();
             println!("Registered project with ID {:?}", project_id)

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -25,6 +25,8 @@ async fn go() -> Result<(), Error> {
         )
         .compat()
         .await?
+        .compat()
+        .await?
         .result
         .unwrap();
     let project_id = (
@@ -41,6 +43,8 @@ async fn go() -> Result<(), Error> {
                 checkpoint_id,
             },
         )
+        .compat()
+        .await?
         .compat()
         .await?;
     println!("{:?}", project_id);

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -31,6 +31,11 @@ async fn go() -> Result<(), Error> {
         },
     );
 
-    client.submit_transaction(transfer_tx).compat().await?;
+    client
+        .submit_transaction(transfer_tx)
+        .compat()
+        .await?
+        .compat()
+        .await?;
     Ok(())
 }

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -14,6 +14,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! Define trait for client backends and provide emulator and remote node implementation
+use futures03::future::BoxFuture;
+
 pub use radicle_registry_runtime::{Hash, UncheckedExtrinsic};
 
 use crate::interface::*;
@@ -43,9 +45,12 @@ pub struct TransactionApplied {
 /// event information from the runtime marks an exception
 #[async_trait::async_trait]
 pub trait Backend {
-    /// Submit a signed transaction to the ledger and return when it has been applied and included
-    /// in a block.
-    async fn submit(&self, xt: UncheckedExtrinsic) -> Result<TransactionApplied, Error>;
+    /// Submit a signed transaction to the ledger and returns a future that resolves when the
+    /// transaction has been applied and included in a block.
+    async fn submit(
+        &self,
+        xt: UncheckedExtrinsic,
+    ) -> Result<BoxFuture<'static, Result<TransactionApplied, Error>>, Error>;
 
     /// Fetch a value from the runtime state storage at the given block.
     async fn fetch(

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -71,24 +71,23 @@ pub type Response<T, Error> = Box<dyn Future<Item = T, Error = Error> + Send>;
 
 /// Trait for ledger clients sending transactions and looking up state.
 pub trait ClientT {
-    /// Submit a signed_transaction with a given ledger call.
+    /// Submit a signed transaction.
     ///
-    /// Succeeds if the transaction has been included in a block.
+    /// Succeeds if the transaction has been accepted by the node. The wrapped future that is
+    /// returned can be used to wait for the transaction to be applied and included in a block.
     fn submit_transaction<Call_: Call>(
         &self,
         transaction: Transaction<Call_>,
-    ) -> Response<TransactionApplied<Call_>, Error>;
+    ) -> Response<Response<TransactionApplied<Call_>, Error>, Error>;
 
     /// Sign and submit a ledger call as a transaction to the blockchain.
     ///
     /// Same as [ClientT::submit_transaction] but takes care of signing the call.
-    ///
-    /// Succeeds if the transaction has been included in a block.
     fn submit<Call_: Call>(
         &self,
         author: &ed25519::Pair,
         call: Call_,
-    ) -> Response<TransactionApplied<Call_>, Error>;
+    ) -> Response<Response<TransactionApplied<Call_>, Error>, Error>;
 
     /// Fetch the nonce for the given account from the chain state
     fn account_nonce(&self, account_id: &AccountId) -> Response<Index, Error>;

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -18,29 +18,25 @@ fn set_checkpoint() {
     let project = common::create_project_with_checkpoint(&client, &charles);
 
     let project_hash2 = H256::random();
-    let new_checkpoint_id = client
-        .submit(
-            &charles,
-            CreateCheckpointParams {
-                project_hash: project_hash2,
-                previous_checkpoint_id: Some(project.current_cp),
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let new_checkpoint_id = common::submit_ok(
+        &client,
+        &charles,
+        CreateCheckpointParams {
+            project_hash: project_hash2,
+            previous_checkpoint_id: Some(project.current_cp),
+        },
+    )
+    .result
+    .unwrap();
 
-    client
-        .submit(
-            &charles,
-            SetCheckpointParams {
-                project_id: project.id.clone(),
-                new_checkpoint_id,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &charles,
+        SetCheckpointParams {
+            project_id: project.id.clone(),
+            new_checkpoint_id,
+        },
+    );
 
     let new_project = client.get_project(project.id).wait().unwrap().unwrap();
     assert_eq!(new_checkpoint_id, new_project.current_cp)
@@ -54,30 +50,26 @@ fn set_checkpoint_without_permission() {
     let project = common::create_project_with_checkpoint(&client, &eve);
 
     let project_hash2 = H256::random();
-    let new_checkpoint_id = client
-        .submit(
-            &eve,
-            CreateCheckpointParams {
-                project_hash: project_hash2,
-                previous_checkpoint_id: Some(project.current_cp),
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let new_checkpoint_id = common::submit_ok(
+        &client,
+        &eve,
+        CreateCheckpointParams {
+            project_hash: project_hash2,
+            previous_checkpoint_id: Some(project.current_cp),
+        },
+    )
+    .result
+    .unwrap();
 
     let frank = common::key_pair_from_string("Frank");
-    let tx_applied = client
-        .submit(
-            &frank,
-            SetCheckpointParams {
-                project_id: project.id.clone(),
-                new_checkpoint_id,
-            },
-        )
-        .wait()
-        .unwrap();
+    let tx_applied = common::submit_ok(
+        &client,
+        &frank,
+        SetCheckpointParams {
+            project_id: project.id.clone(),
+            new_checkpoint_id,
+        },
+    );
 
     let updated_project = client
         .get_project(project.id.clone())
@@ -98,16 +90,14 @@ fn fail_to_set_nonexistent_checkpoint() {
 
     let garbage = CheckpointId::random();
 
-    let tx_applied = client
-        .submit(
-            &david,
-            SetCheckpointParams {
-                project_id: project.id.clone(),
-                new_checkpoint_id: garbage,
-            },
-        )
-        .wait()
-        .unwrap();
+    let tx_applied = common::submit_ok(
+        &client,
+        &david,
+        SetCheckpointParams {
+            project_id: project.id.clone(),
+            new_checkpoint_id: garbage,
+        },
+    );
 
     assert_eq!(tx_applied.result, Err(None));
     let updated_project = client
@@ -132,45 +122,39 @@ fn set_fork_checkpoint() {
     let n = 5;
     let mut checkpoints: Vec<CheckpointId> = Vec::with_capacity(n);
     for _ in 0..n {
-        let new_checkpoint_id = client
-            .submit(
-                &grace,
-                CreateCheckpointParams {
-                    project_hash: H256::random(),
-                    previous_checkpoint_id: (Some(current_cp)),
-                },
-            )
-            .wait()
-            .unwrap()
-            .result
-            .unwrap();
+        let new_checkpoint_id = common::submit_ok(
+            &client,
+            &grace,
+            CreateCheckpointParams {
+                project_hash: H256::random(),
+                previous_checkpoint_id: (Some(current_cp)),
+            },
+        )
+        .result
+        .unwrap();
         current_cp = new_checkpoint_id;
         checkpoints.push(new_checkpoint_id);
     }
 
-    let forked_checkpoint_id = client
-        .submit(
-            &grace,
-            CreateCheckpointParams {
-                project_hash: H256::random(),
-                previous_checkpoint_id: (Some(checkpoints[2])),
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let forked_checkpoint_id = common::submit_ok(
+        &client,
+        &grace,
+        CreateCheckpointParams {
+            project_hash: H256::random(),
+            previous_checkpoint_id: (Some(checkpoints[2])),
+        },
+    )
+    .result
+    .unwrap();
 
-    client
-        .submit(
-            &grace,
-            SetCheckpointParams {
-                project_id: project.id.clone(),
-                new_checkpoint_id: forked_checkpoint_id,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &grace,
+        SetCheckpointParams {
+            project_id: project.id.clone(),
+            new_checkpoint_id: forked_checkpoint_id,
+        },
+    );
 
     let project_1 = client.get_project(project.id).wait().unwrap().unwrap();
 

--- a/runtime/tests/checkpoint_creation.rs
+++ b/runtime/tests/checkpoint_creation.rs
@@ -15,32 +15,28 @@ fn create_checkpoint() {
     let bob = common::key_pair_from_string("Bob");
 
     let project_hash1 = H256::random();
-    let checkpoint_id1 = client
-        .submit(
-            &bob,
-            CreateCheckpointParams {
-                project_hash: project_hash1,
-                previous_checkpoint_id: None,
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let checkpoint_id1 = common::submit_ok(
+        &client,
+        &bob,
+        CreateCheckpointParams {
+            project_hash: project_hash1,
+            previous_checkpoint_id: None,
+        },
+    )
+    .result
+    .unwrap();
 
     let project_hash2 = H256::random();
-    let checkpoint_id2 = client
-        .submit(
-            &bob,
-            CreateCheckpointParams {
-                project_hash: project_hash2,
-                previous_checkpoint_id: Some(checkpoint_id1),
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let checkpoint_id2 = common::submit_ok(
+        &client,
+        &bob,
+        CreateCheckpointParams {
+            project_hash: project_hash2,
+            previous_checkpoint_id: Some(checkpoint_id1),
+        },
+    )
+    .result
+    .unwrap();
 
     let checkpoint1_ = Checkpoint {
         parent: None,
@@ -73,16 +69,14 @@ fn create_checkpoint_without_parent() {
     let project_hash = H256::random();
     let previous_checkpoint_id = Some(CheckpointId::random());
 
-    let tx_applied = client
-        .submit(
-            &bob,
-            CreateCheckpointParams {
-                project_hash,
-                previous_checkpoint_id,
-            },
-        )
-        .wait()
-        .unwrap();
+    let tx_applied = common::submit_ok(
+        &client,
+        &bob,
+        CreateCheckpointParams {
+            project_hash,
+            previous_checkpoint_id,
+        },
+    );
 
     assert_eq!(tx_applied.result, Err(None))
 }

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -15,20 +15,18 @@ fn register_project() {
     let alice = common::key_pair_from_string("Alice");
 
     let project_hash = H256::random();
-    let checkpoint_id = client
-        .submit(
-            &alice,
-            CreateCheckpointParams {
-                project_hash,
-                previous_checkpoint_id: None,
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let checkpoint_id = common::submit_ok(
+        &client,
+        &alice,
+        CreateCheckpointParams {
+            project_hash,
+            previous_checkpoint_id: None,
+        },
+    )
+    .result
+    .unwrap();
     let params = common::random_register_project_params(checkpoint_id);
-    let tx_applied = client.submit(&alice, params.clone()).wait().unwrap();
+    let tx_applied = common::submit_ok(&client, &alice, params.clone());
 
     let project = client
         .get_project(params.clone().id)
@@ -70,35 +68,31 @@ fn register_project_with_duplicate_id() {
     let client = Client::new_emulator();
     let alice = common::key_pair_from_string("Alice");
 
-    let checkpoint_id = client
-        .submit(
-            &alice,
-            CreateCheckpointParams {
-                project_hash: H256::random(),
-                previous_checkpoint_id: None,
-            },
-        )
-        .wait()
-        .unwrap()
-        .result
-        .unwrap();
+    let checkpoint_id = common::submit_ok(
+        &client,
+        &alice,
+        CreateCheckpointParams {
+            project_hash: H256::random(),
+            previous_checkpoint_id: None,
+        },
+    )
+    .result
+    .unwrap();
 
     let params = common::random_register_project_params(checkpoint_id);
 
-    client.submit(&alice, params.clone()).wait().unwrap();
+    common::submit_ok(&client, &alice, params.clone());
 
     // Duplicate submission with different description and image URL.
-    let registration_2 = client
-        .submit(
-            &alice,
-            RegisterProjectParams {
-                description: "DESCRIPTION_2".to_string(),
-                img_url: "IMG_URL_2".to_string(),
-                ..params.clone()
-            },
-        )
-        .wait()
-        .unwrap();
+    let registration_2 = common::submit_ok(
+        &client,
+        &alice,
+        RegisterProjectParams {
+            description: "DESCRIPTION_2".to_string(),
+            img_url: "IMG_URL_2".to_string(),
+            ..params.clone()
+        },
+    );
 
     assert_eq!(registration_2.result, Err(None));
 
@@ -117,7 +111,7 @@ fn register_project_with_bad_checkpoint() {
 
     let params = common::random_register_project_params(checkpoint_id);
 
-    let tx_applied = client.submit(&alice, params.clone()).wait().unwrap();
+    let tx_applied = common::submit_ok(&client, &alice, params.clone());
 
     assert_eq!(tx_applied.result, Err(None));
 

--- a/runtime/tests/transfer.rs
+++ b/runtime/tests/transfer.rs
@@ -16,16 +16,14 @@ fn transfer_fail() {
     let bob = common::key_pair_from_string("Bob").public();
 
     let balance_alice = client.free_balance(&alice.public()).wait().unwrap();
-    let tx_applied = client
-        .submit(
-            &alice,
-            TransferParams {
-                recipient: bob,
-                balance: balance_alice + 1,
-            },
-        )
-        .wait()
-        .unwrap();
+    let tx_applied = common::submit_ok(
+        &client,
+        &alice,
+        TransferParams {
+            recipient: bob,
+            balance: balance_alice + 1,
+        },
+    );
     assert_eq!(tx_applied.result, Err(None));
 }
 
@@ -39,16 +37,14 @@ fn project_account_transfer() {
     let project = common::create_project_with_checkpoint(&client, &alice);
 
     assert_eq!(client.free_balance(&project.account_id).wait().unwrap(), 0);
-    client
-        .submit(
-            &alice,
-            TransferParams {
-                recipient: project.account_id,
-                balance: 2000,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &alice,
+        TransferParams {
+            recipient: project.account_id,
+            balance: 2000,
+        },
+    );
     assert_eq!(
         client.free_balance(&project.account_id).wait().unwrap(),
         2000
@@ -56,17 +52,15 @@ fn project_account_transfer() {
 
     assert_eq!(client.free_balance(&bob).wait().unwrap(), 0);
 
-    client
-        .submit(
-            &alice,
-            TransferFromProjectParams {
-                project: project.id.clone(),
-                recipient: bob,
-                value: 1000,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &alice,
+        TransferFromProjectParams {
+            project: project.id.clone(),
+            recipient: bob,
+            value: 1000,
+        },
+    );
     assert_eq!(client.free_balance(&bob).wait().unwrap(), 1000);
     assert_eq!(
         client.free_balance(&project.account_id).wait().unwrap(),
@@ -82,32 +76,28 @@ fn project_account_transfer_non_member() {
     let bob = common::key_pair_from_string("Bob");
     let project = common::create_project_with_checkpoint(&client, &alice);
 
-    client
-        .submit(
-            &alice,
-            TransferParams {
-                recipient: project.account_id,
-                balance: 2000,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &alice,
+        TransferParams {
+            recipient: project.account_id,
+            balance: 2000,
+        },
+    );
     assert_eq!(
         client.free_balance(&project.account_id).wait().unwrap(),
         2000
     );
 
-    client
-        .submit(
-            &bob,
-            TransferFromProjectParams {
-                project: project.id.clone(),
-                recipient: bob.public(),
-                value: 1000,
-            },
-        )
-        .wait()
-        .unwrap();
+    common::submit_ok(
+        &client,
+        &bob,
+        TransferFromProjectParams {
+            project: project.id.clone(),
+            recipient: bob.public(),
+            value: 1000,
+        },
+    );
 
     assert_eq!(
         client.free_balance(&project.account_id).wait().unwrap(),


### PR DESCRIPTION
`Client::submit` and  `Client::submit_transaction` now return a wrapped future. This allows consumers to distinguish the accepted and applied states of a transaction.

To implement this we change the backend interface and implementation accordingly.

We also add tests for invalid transactions.