### PR TITLE
Remove tx submit convenience methods on Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Upcoming
 
 ### Breaking changes
 
+* Remove convenience methods for submitting transactions from the client
+  - `Client::transfer`
+  - `Client::register_project`
+  - `Client::create_checkpoint`
+  - `Client::set_checkpoint`
+  Calls to these functions can be replaced by calls to `Client::submit`.
 * Eliminate `ClientWithExecutor`, use `Client::create_with_executor()` instead.
 * Eliminate `MemoryClient`. The memory client is now called the emulator and can
   be created with `Client::new_emulator()`.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,9 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use futures01::prelude::*;
-use radicle_registry_client::{
-    ed25519, Client, ClientT, CryptoPair as _, RegisterProjectParams, String32, H256,
-};
+use radicle_registry_client::*;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug, Clone)]
@@ -63,12 +61,20 @@ fn run(args: Args) {
         } => {
             let client = Client::create_with_executor().unwrap();
             let checkpoint_id = client
-                .create_checkpoint(&author_key_pair, project_hash, None)
+                .submit(
+                    &author_key_pair,
+                    CreateCheckpointParams {
+                        project_hash,
+                        previous_checkpoint_id: None,
+                    },
+                )
                 .wait()
+                .unwrap()
+                .result
                 .unwrap();
             let project_id = (name, domain);
             client
-                .register_project(
+                .submit(
                     &author_key_pair,
                     RegisterProjectParams {
                         id: project_id.clone(),

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -2,10 +2,7 @@ use futures01::future::Future;
 use futures03::compat::{Compat, Future01CompatExt};
 use futures03::future::FutureExt;
 
-use radicle_registry_client::{
-    ed25519, Client, ClientT as _, CryptoPair as _, Error, RegisterProjectParams, H256,
-};
-use radicle_registry_runtime::registry::{ProjectDomain, ProjectName};
+use radicle_registry_client::*;
 
 fn main() {
     env_logger::init();
@@ -19,15 +16,23 @@ async fn go() -> Result<(), Error> {
     let client = Client::create().compat().await?;
     let project_hash = H256::random();
     let checkpoint_id = client
-        .create_checkpoint(&alice, project_hash, None)
+        .submit(
+            &alice,
+            CreateCheckpointParams {
+                project_hash,
+                previous_checkpoint_id: None,
+            },
+        )
         .compat()
-        .await?;
+        .await?
+        .result
+        .unwrap();
     let project_id = (
         ProjectName::from_string("NAME".to_string()).unwrap(),
         ProjectDomain::from_string("DOMAIN".to_string()).unwrap(),
     );
     client
-        .register_project(
+        .submit(
             &alice,
             RegisterProjectParams {
                 id: project_id.clone(),

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -96,37 +96,11 @@ pub trait ClientT {
     /// Return the gensis hash of the chain we are communicating with.
     fn genesis_hash(&self) -> Hash;
 
-    fn transfer(
-        &self,
-        key_pair: &ed25519::Pair,
-        recipient: &AccountId,
-        balance: Balance,
-    ) -> Response<(), Error>;
-
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error>;
-
-    fn register_project(
-        &self,
-        author: &ed25519::Pair,
-        project_params: RegisterProjectParams,
-    ) -> Response<(), Error>;
 
     fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Error>;
 
     fn list_projects(&self) -> Response<Vec<ProjectId>, Error>;
 
-    fn create_checkpoint(
-        &self,
-        author: &ed25519::Pair,
-        project_hash: H256,
-        previous_checkpoint_id: Option<CheckpointId>,
-    ) -> Response<CheckpointId, Error>;
-
     fn get_checkpoint(&self, id: CheckpointId) -> Response<Option<Checkpoint>, Error>;
-
-    fn set_checkpoint(
-        &self,
-        author: &ed25519::Pair,
-        params: SetCheckpointParams,
-    ) -> Response<(), Error>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -44,7 +44,6 @@ use parity_scale_codec::{Decode, FullCodec};
 
 use paint_support::storage::generator::{StorageMap, StorageValue};
 use radicle_registry_runtime::{balances, registry, Runtime};
-use sr_primitives::traits::Hash as _;
 
 mod backend;
 mod call;
@@ -222,34 +221,8 @@ impl ClientT for Client {
         Box::new(self.fetch_map_value::<paint_system::AccountNonce<Runtime>, _, _>(*account_id))
     }
 
-    fn transfer(
-        &self,
-        key_pair: &ed25519::Pair,
-        recipient: &AccountId,
-        balance: Balance,
-    ) -> Response<(), Error> {
-        Box::new(
-            self.submit(
-                key_pair,
-                TransferParams {
-                    recipient: *recipient,
-                    balance,
-                },
-            )
-            .map(|_| ()),
-        )
-    }
-
     fn free_balance(&self, account_id: &AccountId) -> Response<Balance, Error> {
         Box::new(self.fetch_map_value::<balances::FreeBalance<Runtime>, _, _>(account_id.clone()))
-    }
-
-    fn register_project(
-        &self,
-        author: &ed25519::Pair,
-        project_params: RegisterProjectParams,
-    ) -> Response<(), Error> {
-        Box::new(self.submit(author, project_params).map(|_| ()))
     }
 
     fn get_project(&self, id: ProjectId) -> Response<Option<Project>, Error> {
@@ -258,36 +231,6 @@ impl ClientT for Client {
 
     fn list_projects(&self) -> Response<Vec<ProjectId>, Error> {
         Box::new(self.fetch_value::<registry::store::ProjectIds, _>())
-    }
-
-    fn create_checkpoint(
-        &self,
-        author: &ed25519::Pair,
-        project_hash: H256,
-        previous_checkpoint_id: Option<CheckpointId>,
-    ) -> Response<CheckpointId, Error> {
-        let checkpoint_id = Hashing::hash_of(&Checkpoint {
-            parent: previous_checkpoint_id,
-            hash: project_hash,
-        });
-        Box::new(
-            self.submit(
-                author,
-                CreateCheckpointParams {
-                    project_hash,
-                    previous_checkpoint_id,
-                },
-            )
-            .map(move |_| checkpoint_id),
-        )
-    }
-
-    fn set_checkpoint(
-        &self,
-        author: &ed25519::Pair,
-        params: SetCheckpointParams,
-    ) -> Response<(), Error> {
-        Box::new(self.submit(author, params).map(|_| ()))
     }
 
     fn get_checkpoint(&self, id: CheckpointId) -> Response<Option<Checkpoint>, Error> {

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -15,8 +15,16 @@ fn register_project() {
 
     let project_hash = H256::random();
     let checkpoint_id = client
-        .create_checkpoint(&alice, project_hash, None)
+        .submit(
+            &alice,
+            CreateCheckpointParams {
+                project_hash,
+                previous_checkpoint_id: None,
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let register_project_params = common::random_register_project_params(checkpoint_id);

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -19,12 +19,20 @@ fn set_checkpoint() {
 
     let project_hash2 = H256::random();
     let new_checkpoint_id = client
-        .create_checkpoint(&charles, project_hash2, Some(project.current_cp))
+        .submit(
+            &charles,
+            CreateCheckpointParams {
+                project_hash: project_hash2,
+                previous_checkpoint_id: Some(project.current_cp),
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     client
-        .set_checkpoint(
+        .submit(
             &charles,
             SetCheckpointParams {
                 project_id: project.id.clone(),
@@ -47,8 +55,16 @@ fn set_checkpoint_without_permission() {
 
     let project_hash2 = H256::random();
     let new_checkpoint_id = client
-        .create_checkpoint(&eve, project_hash2, Some(project.current_cp))
+        .submit(
+            &eve,
+            CreateCheckpointParams {
+                project_hash: project_hash2,
+                previous_checkpoint_id: Some(project.current_cp),
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let frank = common::key_pair_from_string("Frank");
@@ -117,20 +133,36 @@ fn set_fork_checkpoint() {
     let mut checkpoints: Vec<CheckpointId> = Vec::with_capacity(n);
     for _ in 0..n {
         let new_checkpoint_id = client
-            .create_checkpoint(&grace, H256::random(), Some(current_cp))
+            .submit(
+                &grace,
+                CreateCheckpointParams {
+                    project_hash: H256::random(),
+                    previous_checkpoint_id: (Some(current_cp)),
+                },
+            )
             .wait()
+            .unwrap()
+            .result
             .unwrap();
         current_cp = new_checkpoint_id;
         checkpoints.push(new_checkpoint_id);
     }
 
     let forked_checkpoint_id = client
-        .create_checkpoint(&grace, H256::random(), Some(checkpoints[2]))
+        .submit(
+            &grace,
+            CreateCheckpointParams {
+                project_hash: H256::random(),
+                previous_checkpoint_id: (Some(checkpoints[2])),
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     client
-        .set_checkpoint(
+        .submit(
             &grace,
             SetCheckpointParams {
                 project_id: project.id.clone(),

--- a/runtime/tests/checkpoint_creation.rs
+++ b/runtime/tests/checkpoint_creation.rs
@@ -16,14 +16,30 @@ fn create_checkpoint() {
 
     let project_hash1 = H256::random();
     let checkpoint_id1 = client
-        .create_checkpoint(&bob, project_hash1, None)
+        .submit(
+            &bob,
+            CreateCheckpointParams {
+                project_hash: project_hash1,
+                previous_checkpoint_id: None,
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let project_hash2 = H256::random();
     let checkpoint_id2 = client
-        .create_checkpoint(&bob, project_hash2, Some(checkpoint_id1))
+        .submit(
+            &bob,
+            CreateCheckpointParams {
+                project_hash: project_hash2,
+                previous_checkpoint_id: Some(checkpoint_id1),
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let checkpoint1_ = Checkpoint {

--- a/runtime/tests/common/mod.rs
+++ b/runtime/tests/common/mod.rs
@@ -8,16 +8,21 @@ use radicle_registry_client::*;
 #[allow(dead_code)]
 pub fn create_project_with_checkpoint(client: &Client, author: &ed25519::Pair) -> Project {
     let checkpoint_id = client
-        .create_checkpoint(&author, H256::random(), None)
+        .submit(
+            &author,
+            CreateCheckpointParams {
+                project_hash: H256::random(),
+                previous_checkpoint_id: None,
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let params = random_register_project_params(checkpoint_id);
 
-    client
-        .register_project(&author, params.clone())
-        .wait()
-        .unwrap();
+    client.submit(&author, params.clone()).wait().unwrap();
 
     client.get_project(params.id).wait().unwrap().unwrap()
 }

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -16,8 +16,16 @@ fn register_project() {
 
     let project_hash = H256::random();
     let checkpoint_id = client
-        .create_checkpoint(&alice, project_hash, None)
+        .submit(
+            &alice,
+            CreateCheckpointParams {
+                project_hash,
+                previous_checkpoint_id: None,
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
     let params = common::random_register_project_params(checkpoint_id);
     let tx_applied = client.submit(&alice, params.clone()).wait().unwrap();
@@ -62,18 +70,22 @@ fn register_project_with_duplicate_id() {
     let client = Client::new_emulator();
     let alice = common::key_pair_from_string("Alice");
 
-    let project_hash = H256::random();
     let checkpoint_id = client
-        .create_checkpoint(&alice, project_hash, None)
+        .submit(
+            &alice,
+            CreateCheckpointParams {
+                project_hash: H256::random(),
+                previous_checkpoint_id: None,
+            },
+        )
         .wait()
+        .unwrap()
+        .result
         .unwrap();
 
     let params = common::random_register_project_params(checkpoint_id);
 
-    client
-        .register_project(&alice, params.clone())
-        .wait()
-        .unwrap();
+    client.submit(&alice, params.clone()).wait().unwrap();
 
     // Duplicate submission with different description and image URL.
     let registration_2 = client

--- a/runtime/tests/transfer.rs
+++ b/runtime/tests/transfer.rs
@@ -40,7 +40,13 @@ fn project_account_transfer() {
 
     assert_eq!(client.free_balance(&project.account_id).wait().unwrap(), 0);
     client
-        .transfer(&alice, &project.account_id, 2000)
+        .submit(
+            &alice,
+            TransferParams {
+                recipient: project.account_id,
+                balance: 2000,
+            },
+        )
         .wait()
         .unwrap();
     assert_eq!(
@@ -77,7 +83,13 @@ fn project_account_transfer_non_member() {
     let project = common::create_project_with_checkpoint(&client, &alice);
 
     client
-        .transfer(&alice, &project.account_id, 2000)
+        .submit(
+            &alice,
+            TransferParams {
+                recipient: project.account_id,
+                balance: 2000,
+            },
+        )
         .wait()
         .unwrap();
     assert_eq!(


### PR DESCRIPTION
As described in #118 we remove the convenience methods for transaction submission from the client and replace them with `Client::submit` calls.