### PR TITLE
Use lazy_static to compute storage keys only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.1",
  "jsonrpc-core-client",
+ "lazy_static",
  "log 0.4.8",
  "pallet-transaction-payment",
  "parity-scale-codec",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.7"
 futures01 = { package = "futures", version = "0.1" }
 futures03 = { package = "futures", version = "0.3", features = ["compat"] }
 jsonrpc-core-client = { version = "14.0", features = ["ws"] }
+lazy_static = "1.4"
 log = "0.4"
 parity-scale-codec = "1.0"
 tokio = "0.1"


### PR DESCRIPTION
We use `lazy_static` to compute the events storage keys only once.