### PR TITLE
Add host parameter to client constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Upcoming
 
 ### Breaking changes
 
-* `Client::create_with_executor` now returns a future instead of a `Result`
+* `Client::create` and `Client::create_with_executor` now require a `host`
+  argument. Use `host = url::Host::parse("127.0.0.1").unwrap()` to have the old
+  behavior.
 * `Client::submit` and  `Client::submit_transaction` now return a wrapped
   future. This allows consumers to distinguish the accepted and applied states
   of a transaction.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
  "tokio-codec 0.1.1",
  "tokio-io 0.1.12",
  "tokio-rustls",
- "url 2.1.0",
+ "url 2.1.1",
  "webpki-roots 0.18.0",
 ]
 
@@ -3057,7 +3057,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "unsigned-varint 0.2.3",
- "url 2.1.0",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -3424,6 +3424,7 @@ dependencies = [
  "pretty_env_logger",
  "radicle-registry-client",
  "structopt",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -5972,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
  "idna 0.2.0",
  "matches",
@@ -6327,7 +6328,7 @@ dependencies = [
  "rand 0.7.2",
  "sha-1",
  "slab",
- "url 2.1.0",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,4 @@ radicle-registry-client = { path = "../client" }
 futures01 = { package = "futures", version = "0.1" }
 pretty_env_logger = "0.3.1"
 structopt = "0.3"
+url = "1.7"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,8 @@ fn run(args: Args) {
             domain,
             project_hash,
         } => {
-            let client = Client::create_with_executor().wait().unwrap();
+            let node_host = url::Host::parse("127.0.0.1").unwrap();
+            let client = Client::create_with_executor(node_host).wait().unwrap();
             let checkpoint_id = client
                 .submit(
                     &author_key_pair,

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -13,7 +13,10 @@ fn main() {
 
 async fn go() -> Result<(), Error> {
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
-    let client = Client::create().compat().await?;
+
+    let node_host = url::Host::parse("127.0.0.1").unwrap();
+    let client = Client::create(node_host).compat().await?;
+
     let project_hash = H256::random();
     let checkpoint_id = client
         .submit(

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -16,7 +16,8 @@ fn main() {
 async fn go() -> Result<(), Error> {
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
     let bob = ed25519::Pair::from_string("//Bob", None).unwrap();
-    let client = Client::create().compat().await?;
+    let node_host = url::Host::parse("127.0.0.1").unwrap();
+    let client = Client::create(node_host).compat().await?;
 
     let account_nonce = client.account_nonce(&alice.public()).compat().await?;
     let transfer_tx = Transaction::new_signed(

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -52,8 +52,8 @@ pub struct RemoteNode {
 }
 
 impl RemoteNode {
-    pub async fn create() -> Result<Self, Error> {
-        let url = Url::parse("ws://127.0.0.1:9944").expect("Is valid url; qed");
+    pub async fn create(host: url::Host) -> Result<Self, Error> {
+        let url = Url::parse(&format!("ws://{}:9944", host)).expect("Is valid url; qed");
         let channel: RpcChannel = jsonrpc_core_client::transports::ws::connect(&url)
             .compat()
             .await?;

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -31,10 +31,10 @@ pub struct RemoteNodeWithExecutor {
 }
 
 impl RemoteNodeWithExecutor {
-    pub async fn create() -> Result<Self, Error> {
+    pub async fn create(host: url::Host) -> Result<Self, Error> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let backend = Executor01CompatExt::compat(runtime.executor())
-            .spawn_with_handle(backend::RemoteNode::create())
+            .spawn_with_handle(backend::RemoteNode::create(host))
             .unwrap()
             .await?;
         Ok(RemoteNodeWithExecutor {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -64,11 +64,11 @@ pub struct Client {
 }
 
 impl Client {
-    /// Connects to a registry node running on localhost and returns a [Client].
+    /// Connects to a registry node running on the given host and returns a [Client].
     ///
-    /// Fails if it cannot connect to a node.
-    pub fn create() -> impl Future<Item = Self, Error = Error> {
-        future03_compat(backend::RemoteNode::create()).map(Self::new)
+    /// Fails if it cannot connect to a node. Uses websocket over port 9944.
+    pub fn create(host: url::Host) -> impl Future<Item = Self, Error = Error> {
+        future03_compat(backend::RemoteNode::create(host)).map(Self::new)
     }
 
     /// Same as [Client::create] but calls to the client spawn futures in an executor owned by the
@@ -76,8 +76,8 @@ impl Client {
     ///
     /// This makes it possible to call [Future::wait] on the client even if that function is called
     /// in an event loop of another executor.
-    pub fn create_with_executor() -> impl Future<Item = Self, Error = Error> {
-        future03_compat(backend::RemoteNodeWithExecutor::create()).map(Self::new)
+    pub fn create_with_executor(host: url::Host) -> impl Future<Item = Self, Error = Error> {
+        future03_compat(backend::RemoteNodeWithExecutor::create(host)).map(Self::new)
     }
 
     /// Create a new client that emulates the registry ledger in memory. See

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -10,7 +10,8 @@ mod common;
 #[test]
 fn register_project() {
     let _ = env_logger::try_init();
-    let client = Client::create_with_executor().wait().unwrap();
+    let node_host = url::Host::parse("127.0.0.1").unwrap();
+    let client = Client::create_with_executor(node_host).wait().unwrap();
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
 
     let project_hash = H256::random();
@@ -71,7 +72,8 @@ fn register_project() {
 /// Submit a transaction with an invalid genesis hash and expect an error.
 fn invalid_transaction() {
     let _ = env_logger::try_init();
-    let client = Client::create_with_executor().wait().unwrap();
+    let node_host = url::Host::parse("127.0.0.1").unwrap();
+    let client = Client::create_with_executor(node_host).wait().unwrap();
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
 
     let transfer_tx = Transaction::new_signed(


### PR DESCRIPTION
We can specify the host the client connects to via the `host` argument.