### PR TITLE
CI cache improvements

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -8,6 +8,7 @@ steps:
     agents:
       platform: "linux"
       production: "true"
+    timeout_in_minutes: 60
     # See https://buildkite.com/docs/pipelines/artifacts for how to download
     # the produced artifacts with Buildkite's agent CLI.
     # To download artifacts without the `buildkite-agent` tool (which only

--- a/ci/run
+++ b/ci/run
@@ -19,11 +19,20 @@ declare -r target_cache="/cache/target"
 # Incremental builds use timestamps of local code. Since we always
 # check it out fresh we can never use incremental builds.
 export CARGO_BUILD_INCREMENTAL=false
+# Most of the caching is done through caching ./target
+export SCCACHE_CACHE_SIZE="1G"
 
-echo "--- Link target dir to cache"
+echo "--- Prepare cache"
+free_cache_space_kb=$(df --output=avail /cache | sed -n 2p)
+min_free_cache_kb=$(( 800 * 1024 ))
+echo "$(( free_cache_space_kb / 1024 )) MiB free space on /cache"
+if [[ $free_cache_space_kb -le $min_free_cache_kb ]]; then
+  echo "Reseting cache with rm -rf /cache/*"
+  du -sh /cache/*
+  rm -rf /cache/*
+fi
 mkdir -p "$target_cache"
 ln -s "$target_cache" ./target
-echo "Size of ./target is $(du -Dsh "./target" | cut -f 1)"
 
 echo "--- scripts/check-license-headers"
 time ./scripts/check-license-headers
@@ -57,6 +66,8 @@ cp -a target/release/radicle-registry-node ci/node-image
 echo "--- Cleanup cache"
 # Remove all executables that need to be rebuild.
 find ./target -maxdepth 2 -executable -type f -exec rm {} \;
+# Remove artifats from local code
+rm -r target/release/deps/radicle* target/release/build/radicle*
 echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
 
 # Upload the node binary to bintray using the commit hash as the version.


### PR DESCRIPTION
* Limit sccache size to 1Gb. Was 10Gb before. Sccache is not super helpful since we cache ./target.
* Clean the whole cache if we have less than 1Gb left.
* Print free cache space