### PR TITLE
[wip] Add Dispatch error variant.

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -15,6 +15,7 @@
 
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
+use sp_runtime::DispatchError;
 
 /// Error that may be returned by any of the [crate::ClientT] methods.
 #[derive(Debug, derive_more::From, derive_more::Display, derive_more::TryInto)]
@@ -23,6 +24,9 @@ pub enum Error {
     Codec(CodecError),
     /// Error from the underlying RPC connection.
     Rpc(RpcError),
+    /// Dispatch error from Substrate.
+    #[display(fmt = "{:?}", "_0")]
+    Dispatch(DispatchError),
     /// Invalid transaction
     InvalidTransaction(),
     /// Other error.


### PR DESCRIPTION
This PR closes https://github.com/radicle-dev/radicle-registry/issues/145 by accounting for the `sp_runtime::DispatchError` that `client/src/call.rs` [uses](https://github.com/radicle-dev/radicle-registry/blob/e46c2caa73cd911d9dd41d3517bf8db3df355db1/client/src/call.rs#L19).