### PR TITLE
Add “Getting Started” example for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Using the Client
 ----------------
 
 The client for the registry node is provided by the `radicle-registry-client`
-package in the `./client` directory.
+package in the `./client` directory. To get started take a look at
+`./client/examples/getting_started.rs`.
 
 You’ll need to build the client with Rust Nightly.
 

--- a/client/examples/getting_started.rs
+++ b/client/examples/getting_started.rs
@@ -1,0 +1,84 @@
+//! Getting started with the client by transfering funds.
+//!
+//! We’re transferring some funds from Alice to Bob and will inspect the node state.
+//!
+//! To run this example you need a running dev node. You can start it with
+//! `./scripts/run-dev-node`.
+use futures03::compat::{Compat, Future01CompatExt};
+use futures03::future::FutureExt;
+
+use radicle_registry_client::*;
+
+// Wrapper to run the async function `go`.
+fn main() {
+    env_logger::init();
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let result = runtime.block_on(Compat::new(go().boxed()));
+    match result {
+        Ok(()) => (),
+        Err(err) => {
+            println!("ERROR: {:?}", err);
+            std::process::exit(1)
+        }
+    }
+}
+
+// We call [Future01CompatExt::compat] on all futures because the client only uses futures v0.1.
+async fn go() -> Result<(), Error> {
+    // Create a key pair to author transactions from some seed data. This account is initialized
+    // with funds on the local development chain.
+    let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
+    println!("Sending funds from //Alice ({})", alice.public());
+
+    // The receiver of the money transfer is Bob. We only need the public key
+    let bob_public = ed25519::Pair::from_string("//Bob", None).unwrap().public();
+    println!("Recipient: //Bob ({})", bob_public);
+
+    // Create and connect to a client on local host
+    let node_host = url::Host::parse("127.0.0.1").unwrap();
+    println!("Connecting to node on {}", node_host);
+    let client = Client::create(node_host).compat().await?;
+
+    // Show balances of Alice’s and Bob’s accounts
+    let balance_alice = client.free_balance(&alice.public()).compat().await?;
+    println!("Balance Alice: {}", balance_alice);
+    let balance_bob = client.free_balance(&bob_public).compat().await?;
+    println!("Balance Bob:   {}", balance_bob);
+
+    // Sign and submit the call. If successful, returns a future that resolves when the transaction
+    // is included in a block.
+    print!("Submitting transfer transaction... ");
+    let transfer_submitted = client
+        .sign_and_submit_call(
+            &alice,
+            TransferParams {
+                recipient: bob_public,
+                balance: 1,
+            },
+        )
+        .compat()
+        .await?;
+    println!("done");
+
+    print!("Waiting for transaction to be included in block... ");
+    let transfer_applied = transfer_submitted.compat().await?;
+    println!("done");
+
+    // We can use the [TransactionApplied] struct to get the block.
+    println!("Transaction included in block {}", transfer_applied.block);
+
+    // We can also use it to get result of applying the transaction in the ledger. This might fail
+    // for example if the transaction author does not have the necessary funds.
+    match transfer_applied.result {
+        Ok(()) => println!("Funds successfully transferred!"),
+        Err(err) => println!("Failed to transfer funds: {:?}", err),
+    }
+
+    // Show the new balances
+    let balance_alice = client.free_balance(&alice.public()).compat().await?;
+    println!("Balance Alice: {}", balance_alice);
+    let balance_bob = client.free_balance(&bob_public).compat().await?;
+    println!("Balance Bob:   {}", balance_bob);
+
+    Ok(())
+}

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -1,3 +1,4 @@
+//! Register a project on the ledger
 use futures01::future::Future;
 use futures03::compat::{Compat, Future01CompatExt};
 use futures03::future::FutureExt;
@@ -17,6 +18,11 @@ async fn go() -> Result<(), Error> {
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create(node_host).compat().await?;
 
+    let project_name = ProjectName::from_string("radicle-registry".to_string()).unwrap();
+    let project_domain = ProjectDomain::from_string("rad".to_string()).unwrap();
+    let project_id = (project_name.clone(), project_domain.clone());
+
+    // Choose some random project hash and create a checkpoint
     let project_hash = H256::random();
     let checkpoint_id = client
         .sign_and_submit_call(
@@ -32,24 +38,28 @@ async fn go() -> Result<(), Error> {
         .await?
         .result
         .unwrap();
-    let project_id = (
-        ProjectName::from_string("NAME".to_string()).unwrap(),
-        ProjectDomain::from_string("DOMAIN".to_string()).unwrap(),
-    );
+
+    // Register the project
     client
         .sign_and_submit_call(
             &alice,
             RegisterProjectParams {
                 id: project_id.clone(),
-                description: "DESCRIPTION".to_string(),
-                img_url: "IMG_URL".to_string(),
+                description: String::default(),
+                img_url: String::default(),
                 checkpoint_id,
             },
         )
         .compat()
         .await?
         .compat()
-        .await?;
-    println!("{:?}", project_id);
+        .await?
+        .result
+        .unwrap();
+
+    println!(
+        "Successfully registered project {}.{}",
+        project_name, project_domain
+    );
     Ok(())
 }

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -19,17 +19,21 @@ async fn go() -> Result<(), Error> {
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create(node_host).compat().await?;
 
+    // Construct `TransactionExtra` data that is required to validate a transaction.
     let account_nonce = client.account_nonce(&alice.public()).compat().await?;
+    let transaction_extra = TransactionExtra {
+        nonce: account_nonce,
+        genesis_hash: client.genesis_hash(),
+    };
+
+    // Construct the transaction
     let transfer_tx = Transaction::new_signed(
         &alice,
         TransferParams {
             recipient: bob.public(),
             balance: 1000,
         },
-        TransactionExtra {
-            nonce: account_nonce,
-            genesis_hash: client.genesis_hash(),
-        },
+        transaction_extra,
     );
 
     client


### PR DESCRIPTION
Add a comprehensively documented “Getting Started” example for the
client and mention it in the readme. Also document the other examples.