### PR TITLE
cli: Add show-genesis-hash command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -146,3 +146,15 @@ impl CommandT for RegisterProject {
         }
     }
 }
+
+#[derive(StructOpt, Debug, Clone)]
+/// Show the genesis hash the node uses
+pub struct ShowGenesisHash {}
+
+impl CommandT for ShowGenesisHash {
+    fn run(&self, command_context: &CommandContext) -> Result<(), ()> {
+        let genesis_hash = command_context.client.genesis_hash();
+        println!("Gensis block hash: 0x{}", hex::encode(genesis_hash));
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,7 @@ enum Command {
     RegisterProject(RegisterProject),
     ListProjects(ListProjects),
     ShowProject(ShowProject),
+    ShowGenesisHash(ShowGenesisHash),
 }
 
 fn main() {
@@ -71,6 +72,7 @@ fn main() {
         Command::RegisterProject(cmd) => cmd.run(&command_context),
         Command::ListProjects(cmd) => cmd.run(&command_context),
         Command::ShowProject(cmd) => cmd.run(&command_context),
+        Command::ShowGenesisHash(cmd) => cmd.run(&command_context),
     };
 
     match result {


### PR DESCRIPTION
Add a `show-genesis-hash` command that allows one to get the gensis hash from a node