### PR TITLE
Drop description and img_url fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Upcoming
 --------
 
 ### Breaking changes
-
+* Drop project fields `description` and `img_url`
 * Rename `Client::submit` to `Client::sign_and_submit_call`.
 * `Client::create` and `Client::create_with_executor` now require a `host`
   argument. Use `host = url::Host::parse("127.0.0.1").unwrap()` to have the old

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -129,8 +129,6 @@ impl CommandT for RegisterProject {
                 &command_context.author_key_pair,
                 RegisterProjectParams {
                     id: project_id,
-                    description: format!(""),
-                    img_url: format!(""),
                     checkpoint_id,
                 },
             )

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -45,8 +45,6 @@ async fn go() -> Result<(), Error> {
             &alice,
             RegisterProjectParams {
                 id: project_id.clone(),
-                description: String::default(),
-                img_url: String::default(),
                 checkpoint_id,
             },
         )

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -38,8 +38,6 @@ fn register_project() {
         .unwrap()
         .unwrap();
     assert_eq!(project.id, register_project_params.id.clone());
-    assert_eq!(project.description, register_project_params.description);
-    assert_eq!(project.img_url, register_project_params.img_url);
     assert_eq!(project.current_cp, register_project_params.checkpoint_id);
 
     assert_eq!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -73,8 +73,6 @@ pub struct Checkpoint {
 pub struct Project {
     pub id: ProjectId,
     pub account_id: AccountId,
-    pub description: String,
-    pub img_url: String,
     pub members: Vec<AccountId>,
     pub current_cp: CheckpointId,
 }

--- a/core/src/messages.rs
+++ b/core/src/messages.rs
@@ -17,8 +17,6 @@
 
 extern crate alloc;
 
-use alloc::prelude::v1::*;
-
 use crate::{AccountId, Balance, CheckpointId, ProjectId};
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
@@ -26,8 +24,6 @@ use sp_core::H256;
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterProjectParams {
     pub id: ProjectId,
-    pub description: String,
-    pub img_url: String,
     pub checkpoint_id: CheckpointId,
 }
 

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -124,8 +124,6 @@ decl_module! {
             let project = Project {
                 id: project_id.clone(),
                 account_id: account_id,
-                description: params.description,
-                img_url: params.img_url,
                 members: vec![sender],
                 current_cp: params.checkpoint_id
             };

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -33,8 +33,6 @@ fn register_project() {
         .unwrap()
         .unwrap();
     assert_eq!(project.id, params.clone().id);
-    assert_eq!(project.description, params.description);
-    assert_eq!(project.img_url, params.img_url);
     assert_eq!(project.current_cp, checkpoint_id);
 
     assert_eq!(
@@ -83,22 +81,14 @@ fn register_project_with_duplicate_id() {
     submit_ok(&client, &alice, params.clone());
 
     // Duplicate submission with different description and image URL.
-    let registration_2 = submit_ok(
-        &client,
-        &alice,
-        RegisterProjectParams {
-            description: "DESCRIPTION_2".to_string(),
-            img_url: "IMG_URL_2".to_string(),
-            ..params.clone()
-        },
-    );
+    let registration_2 = submit_ok(&client, &alice, RegisterProjectParams { ..params.clone() });
 
     assert_eq!(registration_2.result, Err(DispatchError::Other("")));
 
-    let project = client.get_project(params.id).wait().unwrap().unwrap();
+    let _project = client.get_project(params.id).wait().unwrap().unwrap();
 
-    assert_eq!(params.description, project.description);
-    assert_eq!(params.img_url, project.img_url)
+    // TODO(nuno): assert that the project data is left untouched.
+    // This can be done again when the metadata field is added.
 }
 
 #[test]

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -71,21 +71,7 @@ pub fn random_register_project_params(checkpoint_id: CheckpointId) -> RegisterPr
         .collect::<String>();
     let id = (name.parse().unwrap(), domain.parse().unwrap());
 
-    let description = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(50)
-        .collect::<String>();
-    let img_url = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(50)
-        .collect::<String>();
-
-    RegisterProjectParams {
-        id,
-        description,
-        img_url,
-        checkpoint_id,
-    }
+    RegisterProjectParams { id, checkpoint_id }
 }
 
 pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {


### PR DESCRIPTION
Closes #137 

These fields were initially included on a common-sense basis but they
turn out to neither be useful neither optimal to keep in a blockchain.
Hereby those two fields are removed from the Project model as well as
from the RegisterProjectParams message a node can receive.