### PR TITLE
Publish master builds to separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Radicle Registry
 ================
 
+[![Build status](https://badge.buildkite.com/dbdd1481a6275cb41c5de15e33b34c159b17a025be13116103.svg)](https://buildkite.com/monadic/radicle-registry)
+[![Download master](https://api.bintray.com/packages/oscoin/radicle-registry-files/radicle-registry/images/download.svg)][package-latest-master]
+
 Experimental Radicle Registry implementation with Substrate.
 
 See [`DEVELOPING.md`][dev-manual] for developer information.
@@ -21,12 +24,14 @@ See [`DEVELOPING.md`][dev-manual] for developer information.
 Getting the Node
 ----------------
 
-We build binaries of the node and docker images for every pushed commit.
+We build binaries of the node and docker images for every pushed commit. Node
+binaries are available for the `x86_64-unknown-linux-gnu` target triple.
 
-Node binaries are available for the `x86_64-unknown-linux-gnu` target triple.
-You can download them from
+You can get the latest master build [here][package-latest-master]
+
+You can directly download node binaries for every build from
 ```
-https://dl.bintray.com/oscoin/radicle-registry-files/git-<COMMIT_SHA>/x86_64-linux-gnu/radicle-registry-node
+https://dl.bintray.com/oscoin/radicle-registry-files/by-commit/$COMMIT_SHA/x86_64-linux-gnu/radicle-registry-node
 ```
 
 You can pull a docker image of the node with
@@ -36,6 +41,8 @@ docker pull gcr.io/opensourcecoin/radicle-registry/node:<commit-sha>
 In the image the node binary is located at `/usr/local/bin/radicle-registry-node`
 
 To build the node from source see [`DEVELOPING.md`][dev-manual].
+
+[package-latest-master]: https://bintray.com/oscoin/radicle-registry-files/radicle-registry/_latestVersion
 
 
 Running the node

--- a/ci/run
+++ b/ci/run
@@ -70,20 +70,34 @@ find ./target -maxdepth 2 -executable -type f -exec rm {} \;
 rm -r target/release/deps/radicle* target/release/build/radicle*
 echo "Size of $target_cache is $(du -sh "$target_cache" | cut -f 1)"
 
-# Upload the node binary to bintray using the commit hash as the version.
+# Upload the node binary to bintray.
+#
+# For master builds we use the `radicle-registry-node` package and the
+# date and build number as the version.
+#
+# For branch builds we use the `radicle-registry-dev` package and the
+# commit hash as the version
 function upload_to_bintray () {
   local -r api_url="https://bintray.com/api/v1"
   local -r subject="oscoin"
   local -r repo="radicle-registry-files"
-  local -r package="radicle-registry-node"
-  local -r version="git-$BUILDKITE_COMMIT"
+
+  if [[ "$BUILDKITE_BRANCH" == "master" ]]; then
+    local -r package="radicle-registry"
+    local -r version="d$(date +%Y-%m-%d).$BUILDKITE_BUILD_NUMBER"
+  else
+    local -r package="radicle-registry-dev"
+    local -r version="git-$BUILDKITE_COMMIT"
+  fi
+
   local -r target_triple="x86_64-linux-gnu"
-  local -r remote_file="$version/$target_triple/radicle-registry-node"
+  local -r remote_file="by-commit/$BUILDKITE_COMMIT/$target_triple/radicle-registry-node"
   local -r local_file="./artifacts/radicle-registry-node"
 
   local file_checksum
   file_checksum="$(sha256sum "$local_file" | cut -f1 -d ' ')"
 
+  echo "Uploading files for $package $version"
   curl \
     --fail --show-error \
     -X PUT \
@@ -91,7 +105,6 @@ function upload_to_bintray () {
     -H "X-Bintray-Package: $package" \
     -H "X-Bintray-Version: $version" \
     -H "X-Bintray-Override: 1" \
-    -H "X-Bintray-Publish: 1" \
     -H "X-Checksum-Sha2: $file_checksum" \
     "$api_url/content/$subject/$repo/$remote_file" \
     --data-binary @$local_file
@@ -100,6 +113,28 @@ function upload_to_bintray () {
 
   local -r download_path="https://dl.bintray.com/$subject/$repo/$remote_file"
   echo "Node binary available from $download_path"
+
+  echo "Publishing $package $version"
+  curl \
+    --fail --show-error \
+    -X POST \
+    --basic --user "$BINTRAY_API_KEY" \
+    -H "content-type: application/json" \
+    "$api_url/content/$subject/$repo/$package/$version/publish" \
+    --data-binary '{ "publish_wait_for_secs": -1 }'
+  # Response from curl does not end with new line
+  echo
+
+  echo "Adding file to download list"
+  curl \
+    --fail --show-error \
+    -X PUT \
+    --basic --user "$BINTRAY_API_KEY" \
+    -H "content-type: application/json" \
+    "$api_url/file_metadata/$subject/$repo/$remote_file" \
+    --data-binary '{ "list_in_downloads": true }'
+  # Response from curl does not end with new line
+  echo
 }
 
 if [[ -n "${BINTRAY_API_KEY:-}" ]]; then


### PR DESCRIPTION
Fixes #154

* Use the package `radicle-registry` for master builds.
* Use `date.build-number` as the version for master builds. E.g. `d2020-01-15.456`
* Use `radicle-registry-dev` package for all other branch builds. Version is still `git-$COMMIT_SHA`
* Add the node binary file to the download list for packages so they’re easily accessible
* Separate publish step so that it is synchronous
* Add download badge that links to bintray