### PR TITLE
Add metadata field to Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Upcoming
 --------
 
 ### Breaking changes
+* Add `metadata` field to Project, a vector of at most 128 bytes.
 * Drop project fields `description` and `img_url`
 * Rename `Client::submit` to `Client::sign_and_submit_call`.
 * `Client::create` and `Client::create_with_executor` now require a `host`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "rand 0.7.3",
  "sp-core",
  "sp-runtime",
  "sp-std",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -133,6 +133,7 @@ impl CommandT for RegisterProject {
                 message::RegisterProject {
                     id: project_id,
                     checkpoint_id,
+                    metadata: Vec::new(),
                 },
             )
             .await

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -133,7 +133,7 @@ impl CommandT for RegisterProject {
                 message::RegisterProject {
                     id: project_id,
                     checkpoint_id,
-                    metadata: Vec::new(),
+                    metadata: Bytes128::random(),
                 },
             )
             .await

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -44,6 +44,7 @@ async fn go() -> Result<(), Error> {
             message::RegisterProject {
                 id: project_id.clone(),
                 checkpoint_id,
+                metadata: Vec::new(),
             },
         )
         .await?

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -44,7 +44,7 @@ async fn go() -> Result<(), Error> {
             message::RegisterProject {
                 id: project_id.clone(),
                 checkpoint_id,
-                metadata: Vec::new(),
+                metadata: Bytes128::random(),
             },
         )
         .await?

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -40,6 +40,7 @@ async fn register_project() {
         .unwrap();
     assert_eq!(project.id, register_project_message.id.clone());
     assert_eq!(project.current_cp, register_project_message.checkpoint_id);
+    assert_eq!(project.metadata, register_project_message.metadata);
 
     assert_eq!(
         tx_applied.events[0],

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,9 @@ std = [
     "sp-runtime/std",
 ]
 
+[dependencies]
+rand = "0.7.2"
+
 [dependencies.parity-scale-codec]
 default-features = false
 features = ["derive", "full"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,13 +15,14 @@ std = [
     "frame-support/std",
     "frame-system/std",
     "parity-scale-codec/std",
+    "rand",
     "sp-core/std",
     "sp-std/std",
     "sp-runtime/std",
 ]
 
 [dependencies]
-rand = "0.7.2"
+rand = { version = "0.7.2", optional = true }
 
 [dependencies.parity-scale-codec]
 default-features = false

--- a/core/src/bytes128.rs
+++ b/core/src/bytes128.rs
@@ -1,0 +1,108 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/// `Bytes128` type, and its validation tests.
+use alloc::format;
+use alloc::prelude::v1::*;
+use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
+
+use sp_std::fmt;
+
+/// This type is used to represent project metadata fields.
+///
+/// Radicle limits the size of the project metadata field to 128 bytes.
+/// To guarantee that at the type-level, a smart constructor is provided to check validity.
+#[derive(Encode, Clone, Debug, Eq, PartialEq)]
+pub struct Bytes128(Vec<u8>);
+
+impl Bytes128 {
+    const MAXIMUM_SUPPORTED_LENGTH: usize = 128;
+
+    pub fn from_vec(vector: Vec<u8>) -> Result<Self, String> {
+        if vector.len() > Self::MAXIMUM_SUPPORTED_LENGTH {
+            Err(format!(
+                "The provided vectors's length exceeded {:?} bytes: {:?}",
+                Self::MAXIMUM_SUPPORTED_LENGTH,
+                vector
+            ))
+        } else {
+            Ok(Bytes128(vector))
+        }
+    }
+
+    //TODO(nuno): remove lint once used elsewhere besides the tests.
+    #[warn(dead_code)]
+    pub fn random() -> Self {
+        Bytes128(
+            (0..Self::MAXIMUM_SUPPORTED_LENGTH)
+                .map(|_| rand::random::<u8>())
+                .collect(),
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl fmt::Display for Bytes128 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl Decode for Bytes128 {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, CodecError> {
+        let decoded: Vec<u8> = Vec::decode(input)?;
+        Bytes128::from_vec(decoded)
+            .or_else(|_| Err(From::from("Bytes128 length was more than 128 characters.")))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_from_valid_sized_vectors() {
+        (0..Bytes128::MAXIMUM_SUPPORTED_LENGTH + 1)
+            .map(|size| random_vector(size))
+            .map(|random_vector| {
+                assert_eq!(
+                    Bytes128::from_vec(random_vector.clone()).unwrap(),
+                    Bytes128(random_vector.clone())
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_from_inordinate_vectors() {
+        (Bytes128::MAXIMUM_SUPPORTED_LENGTH + 1..Bytes128::MAXIMUM_SUPPORTED_LENGTH + 10)
+            .map(|size| random_vector(size))
+            .map(|random_vector| assert!(Bytes128::from_vec(random_vector.clone()).is_err()))
+            .collect()
+    }
+
+    #[test]
+    fn decode_after_encode_is_identity() {
+        let bytes128 = Bytes128::random();
+        let encoded = bytes128.encode();
+        let decoded = <Bytes128>::decode(&mut &encoded[..]).unwrap();
+
+        assert_eq!(bytes128, decoded)
+    }
+
+    fn random_vector(size: usize) -> Vec<u8> {
+        (0..size).map(|_| rand::random::<u8>()).collect()
+    }
+}

--- a/core/src/bytes128.rs
+++ b/core/src/bytes128.rs
@@ -42,14 +42,16 @@ impl Bytes128 {
         }
     }
 
-    //TODO(nuno): remove lint once used elsewhere besides the tests.
-    #[warn(dead_code)]
     pub fn random() -> Self {
-        Bytes128(
-            (0..Self::MAXIMUM_SUPPORTED_LENGTH)
-                .map(|_| rand::random::<u8>())
-                .collect(),
-        )
+        Self::from_vec(Self::random_vector(Self::MAXIMUM_SUPPORTED_LENGTH)).unwrap()
+    }
+
+    pub fn random_with_size(size: usize) -> Result<Self, String> {
+        Bytes128::from_vec(Self::random_vector(size))
+    }
+
+    fn random_vector(size: usize) -> Vec<u8> {
+        (0..size).map(|_| rand::random::<u8>()).collect()
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,6 +27,8 @@ use parity_scale_codec::{Decode, Encode};
 pub mod message;
 
 mod bytes128;
+pub use bytes128::Bytes128;
+
 mod string32;
 use sp_runtime::traits::BlakeTwo256;
 pub use string32::String32;
@@ -76,5 +78,5 @@ pub struct Project {
     pub account_id: AccountId,
     pub members: Vec<AccountId>,
     pub current_cp: CheckpointId,
-    pub metadata: Vec<u8>,
+    pub metadata: Bytes128,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,4 +75,5 @@ pub struct Project {
     pub account_id: AccountId,
     pub members: Vec<AccountId>,
     pub current_cp: CheckpointId,
+    pub metadata: Vec<u8>,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -26,6 +26,7 @@ pub use frame_support::dispatch::DispatchError;
 use parity_scale_codec::{Decode, Encode};
 pub mod message;
 
+mod bytes128;
 mod string32;
 use sp_runtime::traits::BlakeTwo256;
 pub use string32::String32;

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -17,8 +17,7 @@
 
 extern crate alloc;
 
-use crate::{AccountId, Balance, CheckpointId, ProjectId};
-use alloc::prelude::v1::Vec;
+use crate::{AccountId, Balance, Bytes128, CheckpointId, ProjectId};
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 
@@ -26,7 +25,7 @@ use sp_core::H256;
 pub struct RegisterProject {
     pub id: ProjectId,
     pub checkpoint_id: CheckpointId,
-    pub metadata: Vec<u8>,
+    pub metadata: Bytes128,
 }
 
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -18,6 +18,7 @@
 extern crate alloc;
 
 use crate::{AccountId, Balance, CheckpointId, ProjectId};
+use alloc::prelude::v1::Vec;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 
@@ -25,6 +26,7 @@ use sp_core::H256;
 pub struct RegisterProject {
     pub id: ProjectId,
     pub checkpoint_id: CheckpointId,
+    pub metadata: Vec<u8>,
 }
 
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]

--- a/core/src/string32.rs
+++ b/core/src/string32.rs
@@ -32,8 +32,8 @@ impl String32 {
     pub fn from_string(s: String) -> Result<Self, String> {
         if s.len() > 32 {
             Err(format!(
-                "The provided string's length exceeded 32 characters: {:?}",
-                s
+                "The provided string's length is {} while String32 is limited to 32 characters.",
+                s.len()
             ))
         } else {
             Ok(String32(s))

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -155,7 +155,8 @@ decl_module! {
                 id: project_id.clone(),
                 account_id: account_id,
                 members: vec![sender],
-                current_cp: message.checkpoint_id
+                current_cp: message.checkpoint_id,
+                metadata: message.metadata
             };
 
             store::Projects::insert(project_id.clone(), project);

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -33,6 +33,7 @@ async fn register_project() {
         .unwrap();
     assert_eq!(project.id, message.clone().id);
     assert_eq!(project.current_cp, checkpoint_id);
+    assert_eq!(project.metadata, message.clone().metadata);
 
     assert_eq!(
         tx_applied.events[0],
@@ -80,16 +81,20 @@ async fn register_project_with_duplicate_id() {
     let registration_2 = submit_ok(
         &client,
         &alice,
-        message::RegisterProject { ..message.clone() },
+        message::RegisterProject {
+            metadata: random_metadata(),
+            ..message.clone()
+        },
     )
     .await;
 
     assert_eq!(registration_2.result, Err(DispatchError::Other("")));
 
-    let _project = client.get_project(message.id).await.unwrap().unwrap();
+    let project = client.get_project(message.id).await.unwrap().unwrap();
 
-    // TODO(nuno): assert that the project data is left untouched.
-    // This can be done again when the metadata field is added.
+    // Assert that the project data was not altered during the
+    // attempt to re-register the already existing project.
+    assert_eq!(message.metadata, project.metadata)
 }
 
 #[async_std::test]

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -82,7 +82,7 @@ async fn register_project_with_duplicate_id() {
         &client,
         &alice,
         message::RegisterProject {
-            metadata: random_metadata(),
+            metadata: Bytes128::random(),
             ..message.clone()
         },
     )

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -74,12 +74,8 @@ pub fn random_register_project_message(checkpoint_id: CheckpointId) -> message::
     message::RegisterProject {
         id,
         checkpoint_id,
-        metadata: random_metadata(),
+        metadata: Bytes128::random(),
     }
-}
-
-pub fn random_metadata() -> Vec<u8> {
-    (0..128).map(|_| rand::random::<u8>()).collect()
 }
 
 pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -71,7 +71,15 @@ pub fn random_register_project_message(checkpoint_id: CheckpointId) -> message::
         .collect::<String>();
     let id = (name.parse().unwrap(), domain.parse().unwrap());
 
-    message::RegisterProject { id, checkpoint_id }
+    message::RegisterProject {
+        id,
+        checkpoint_id,
+        metadata: random_metadata(),
+    }
+}
+
+pub fn random_metadata() -> Vec<u8> {
+    (0..128).map(|_| rand::random::<u8>()).collect()
 }
 
 pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {


### PR DESCRIPTION
Closes #156 

This PR adds a new `metadata` field to Project. This fields is a `Vec<u8>`, that can be anything serialized as an array of bytes. What is and how it's (de)serialized is out of the Registry's scope.

### Note

@geigerzaehler on #156 you mention this field should host at most 128 bytes. I'd thus make it `Vec<[u8; 128]>`. To avoid duplication, I'd prefer to have at least a type alias. Just want to double-check to know how you guys go about this. Also, how will the Registry act when given metadata with more than 128 bytes? Will it take the first 128 or refuse the request?

### TODO 

- [x] Add metadata field
- [x] Fix tests
- [x] Create `Bytes128` type
- [x] Replace `Vec<u8>` with `Bytes128`
- [x] Validate valid `metadata`