### PR TITLE
ci: Ignore error when adjusting bintray release

### DIFF
--- a/ci/run
+++ b/ci/run
@@ -126,8 +126,8 @@ function upload_to_bintray () {
   echo
 
   echo "Adding file to download list"
+  # We ignore errors. This is not crucial for the build to pass
   curl \
-    --fail --show-error \
     -X PUT \
     --basic --user "$BINTRAY_API_KEY" \
     -H "content-type: application/json" \


### PR DESCRIPTION
We don’t fail a CI build when we fail to add an uploaded file on bintray to the download list. Having a file in the download list is purely presentational.