### PR TITLE
cli: Add project-transfer command

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -169,7 +169,7 @@ impl CommandT for ShowGenesisHash {
 }
 
 #[derive(StructOpt, Debug, Clone)]
-/// Transfer some funds to recipient
+/// Transfer funds to recipient
 pub struct Transfer {
     #[structopt(parse(try_from_str = parse_account_id))]
     /// Recipient Account in SS58 address format

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -66,12 +66,12 @@ impl Args {
 
 #[derive(StructOpt, Debug, Clone)]
 enum Command {
-    RegisterProject(RegisterProject),
     ListProjects(ListProjects),
-    ShowProject(ShowProject),
-    ShowGenesisHash(ShowGenesisHash),
-    Transfer(Transfer),
+    RegisterProject(RegisterProject),
     ShowBalance(ShowBalance),
+    ShowGenesisHash(ShowGenesisHash),
+    ShowProject(ShowProject),
+    Transfer(Transfer),
     TransferProjectFunds(TransferProjectFunds),
 }
 
@@ -82,12 +82,12 @@ async fn main() {
     let command_context = args.command_context().await;
 
     let result = match args.command {
-        Command::RegisterProject(cmd) => cmd.run(&command_context).await,
         Command::ListProjects(cmd) => cmd.run(&command_context).await,
-        Command::ShowProject(cmd) => cmd.run(&command_context).await,
-        Command::ShowGenesisHash(cmd) => cmd.run(&command_context).await,
-        Command::Transfer(cmd) => cmd.run(&command_context).await,
+        Command::RegisterProject(cmd) => cmd.run(&command_context).await,
         Command::ShowBalance(cmd) => cmd.run(&command_context).await,
+        Command::ShowGenesisHash(cmd) => cmd.run(&command_context).await,
+        Command::ShowProject(cmd) => cmd.run(&command_context).await,
+        Command::Transfer(cmd) => cmd.run(&command_context).await,
         Command::TransferProjectFunds(cmd) => cmd.run(&command_context).await,
     };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -72,6 +72,7 @@ enum Command {
     ShowGenesisHash(ShowGenesisHash),
     Transfer(Transfer),
     ShowBalance(ShowBalance),
+    TransferProjectFunds(TransferProjectFunds),
 }
 
 #[async_std::main]
@@ -87,6 +88,7 @@ async fn main() {
         Command::ShowGenesisHash(cmd) => cmd.run(&command_context).await,
         Command::Transfer(cmd) => cmd.run(&command_context).await,
         Command::ShowBalance(cmd) => cmd.run(&command_context).await,
+        Command::TransferProjectFunds(cmd) => cmd.run(&command_context).await,
     };
 
     match result {


### PR DESCRIPTION
We add the `project-transfer` command to the cli to transfer funds from a project to an arbitrary account.