### PR TITLE
Use storage prefix APIs for project listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,6 +3531,7 @@ dependencies = [
  "sp-io",
  "sp-rpc",
  "sp-runtime",
+ "sp-state-machine",
  "sp-transaction-pool",
  "tokio 0.1.22",
  "url 1.7.2",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -58,6 +58,10 @@ rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
 git = "https://github.com/paritytech/substrate"
 rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
 
+[dependencies.sp-state-machine]
+git = "https://github.com/paritytech/substrate"
+rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
+
 [dependencies.sp-transaction-pool]
 git = "https://github.com/paritytech/substrate"
 rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -59,6 +59,13 @@ pub trait Backend {
         block_hash: Option<BlockHash>,
     ) -> Result<Option<Vec<u8>>, Error>;
 
+    /// Fetch all keys with the given prefix from the state storage at the given block.
+    async fn fetch_keys(
+        &self,
+        prefix: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Vec<Vec<u8>>, Error>;
+
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;
 }

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -191,6 +191,21 @@ impl backend::Backend for RemoteNode {
         Ok(maybe_data.map(|data| data.0))
     }
 
+    async fn fetch_keys(
+        &self,
+        prefix: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let prefix = StorageKey(Vec::from(prefix));
+        let keys = self
+            .rpc
+            .state
+            .storage_keys(prefix, block_hash)
+            .compat()
+            .await?;
+        Ok(keys.into_iter().map(|key| key.0).collect())
+    }
+
     fn get_genesis_hash(&self) -> Hash {
         self.genesis_hash
     }

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -72,6 +72,19 @@ impl backend::Backend for RemoteNodeWithExecutor {
         handle.await
     }
 
+    async fn fetch_keys(
+        &self,
+        prefix: &[u8],
+        block_hash: Option<BlockHash>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let backend = self.backend.clone();
+        let prefix = Vec::from(prefix);
+        let handle = Executor01CompatExt::compat(self.runtime.executor())
+            .spawn_with_handle(async move { backend.fetch_keys(&prefix, block_hash).await })
+            .unwrap();
+        handle.await
+    }
+
     fn get_genesis_hash(&self) -> Hash {
         self.backend.get_genesis_hash()
     }


### PR DESCRIPTION
Instead of storing the project lists in a dedicated place in the chain state we use the storage prefix APIs to get the list of all projects.

We keep the private `Client::fetch_value` method alive since we’ll definitely need it in the future.