### PR TITLE
ci: Check Wasm build with clippy

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,8 +12,9 @@ The code is bootstrapped with the [`substrate-node-template`][node-template].
 - [Build requirements](#build-requirements)
 - [Running development node](#running-development-node)
 - [Packages](#packages)
-- [Running tests](#running-tests)
+- [Running checks and tests](#running-checks-and-tests)
 - [Changelog](#changelog)
+- [Continuous Deployment](#continuous-deployment)
 - [Local devnet](#local-devnet)
 - [Updating substrate](#updating-substrate)
 - [Updating Continuous Integration's base Docker image](#updating-continuous-integrations-base-docker-image)
@@ -65,8 +66,23 @@ Packages
   it should probably go into `core`.
 
 
-Running tests
--------------
+Running checks and tests
+------------------------
+
+We check our code with clippy and `cargo fmt`
+```
+cargo clippy --workspace --all-targets -- -D clippy::all
+cargo fmt --workspace -- --check
+```
+
+To check the Wasm build of the runtime run
+```
+cargo clippy \
+  --manifest-path runtime/Cargo.toml \
+  --no-default-features \
+  --target wasm32-unknown-unknown \
+  -- -D clippy::all
+```
 
 You can run all tests with `cargo test --workspace --all-targets`. For the
 end-to-end tests you need to [build and run a dev

--- a/ci/run
+++ b/ci/run
@@ -44,10 +44,14 @@ time ./scripts/check-license-headers
 echo "--- cargo fmt"
 time cargo fmt --all -- --check
 
-echo "--- cargo build"
 export BUILD_DUMMY_WASM_BINARY=0
 export RUSTFLAGS="-D warnings"
+
+echo "--- cargo clippy"
 cargo clippy --workspace --all-targets --release -- -D clippy::all
+echo "--- cargo clippy (for wasm32 target)"
+cargo clippy --manifest-path runtime/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D clippy::all
+echo "--- cargo build"
 cargo build --workspace --all-targets --release
 
 echo "--- cargo test"


### PR DESCRIPTION
Check the Wasm build with `clippy` on CI. We also document the checks.