### PR TITLE
Cleanup `core` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,13 +3541,10 @@ dependencies = [
 name = "radicle-registry-core"
 version = "0.0.0"
 dependencies = [
- "frame-support",
- "frame-system",
  "parity-scale-codec",
  "rand 0.7.3",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,12 +12,9 @@ repository = "https://github.com/radicle-dev/radicle-registry"
 [features]
 default = ["std"]
 std = [
-    "frame-support/std",
-    "frame-system/std",
     "parity-scale-codec/std",
     "rand",
     "sp-core/std",
-    "sp-std/std",
     "sp-runtime/std",
 ]
 
@@ -35,21 +32,6 @@ rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
 default-features = false
 
 [dependencies.sp-runtime]
-git = "https://github.com/paritytech/substrate"
-rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
-default-features = false
-
-[dependencies.frame-support]
-git = "https://github.com/paritytech/substrate"
-rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
-default-features = false
-
-[dependencies.frame-system]
-git = "https://github.com/paritytech/substrate"
-rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
-default-features = false
-
-[dependencies.sp-std]
 git = "https://github.com/paritytech/substrate"
 rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
 default-features = false

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,18 +22,19 @@ extern crate alloc;
 
 use alloc::prelude::v1::*;
 
-pub use frame_support::dispatch::DispatchError;
 use parity_scale_codec::{Decode, Encode};
+use sp_core::{ed25519, H256};
+use sp_runtime::traits::BlakeTwo256;
+
+pub use sp_runtime::DispatchError;
+
 pub mod message;
 
 mod bytes128;
 pub use bytes128::Bytes128;
 
 mod string32;
-use sp_runtime::traits::BlakeTwo256;
 pub use string32::String32;
-
-use sp_core::{ed25519, H256};
 
 /// Index of a transaction in the chain.
 pub type Index = u32;

--- a/core/src/string32.rs
+++ b/core/src/string32.rs
@@ -18,9 +18,6 @@ use alloc::format;
 use alloc::prelude::v1::*;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 
-use sp_std::fmt;
-use sp_std::str::FromStr;
-
 /// Type to represent project names and domains.
 ///
 /// Since their lengths are limited to 32 characters, a smart constructor is
@@ -41,7 +38,7 @@ impl String32 {
     }
 }
 
-impl FromStr for String32 {
+impl core::str::FromStr for String32 {
     type Err = String;
 
     /// This function only raises an error if the `String` it is passed is
@@ -52,8 +49,8 @@ impl FromStr for String32 {
 }
 
 #[cfg(feature = "std")]
-impl fmt::Display for String32 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl core::fmt::Display for String32 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -14,23 +14,22 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::vec;
-use frame_support::weights::SimpleDispatchInfo;
+
 use frame_support::{
     decl_event, decl_module, decl_storage,
     dispatch::DispatchResult,
     storage::StorageMap as _,
     traits::{Currency, ExistenceRequirement, Randomness as _},
+    weights::SimpleDispatchInfo,
 };
-
-use sp_core::crypto::UncheckedFrom;
-
-use frame_system as system;
+use frame_system as system; // required for `decl_module!` to work
 use frame_system::ensure_signed;
-
-use crate::{AccountId, Hash, Hashing};
+use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Hash as _;
 
 use radicle_registry_core::*;
+
+use crate::{AccountId, Hash, Hashing};
 
 pub trait Trait:
     frame_system::Trait<AccountId = AccountId, Origin = crate::Origin, Hash = Hash>


### PR DESCRIPTION
We remove all dependencies from `core` that are not needed. Some of them were just used for type aliases that we can also get from other dependencies.

Also regrouped the imports in the registry runtime code.