### PR TITLE
Refactor registry errors to use DispatchError::Module

### DIFF
--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -109,7 +109,7 @@ impl RemoteNode {
             Some(tx_status) => match tx_status {
                 TxStatus::Future | TxStatus::Ready | TxStatus::Broadcast(_) => (),
                 TxStatus::InBlock(_block_hash) => {
-                    return Err("Invalid tx status \"Finalized\"".into())
+                    return Err("Invalid tx status \"InBlock\"".into())
                 }
                 TxStatus::Usurped(_) => return Err("Extrinsic Usurped".into()),
                 TxStatus::Dropped => return Err("Extrinsic Dropped".into()),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,60 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::DispatchError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Errors describing failed Registry transactions.
+pub enum RegistryError {
+    InexistentCheckpointId = 0,
+    DuplicateProjectId,
+    InexistentProjectId,
+    InsufficientSenderPermissions,
+    InexistentParentCheckpoint,
+    InexistentInitialProjectCheckpoint,
+    InvalidCheckpointAncestry,
+}
+
+impl From<RegistryError> for &'static str {
+    fn from(error: RegistryError) -> &'static str {
+        match error {
+            RegistryError::InexistentCheckpointId => "The provided checkpoint does not exist",
+            RegistryError::DuplicateProjectId => "A project with a similar ID already exists.",
+            RegistryError::InexistentProjectId => "Project does not exist",
+            RegistryError::InsufficientSenderPermissions => "Sender is not a project member",
+            RegistryError::InexistentParentCheckpoint => "Parent checkpoint does not exist",
+            RegistryError::InexistentInitialProjectCheckpoint => {
+                "A registered project must have an initial checkpoint."
+            }
+            RegistryError::InvalidCheckpointAncestry => {
+                "The provided checkpoint is not a descendant of the project's initial checkpoint."
+            }
+        }
+    }
+}
+
+impl From<RegistryError> for DispatchError {
+    fn from(error: RegistryError) -> Self {
+        // This is the index with which the registry runtime module is declared
+        // in the Radicle Registry runtime - see the `construct_runtime`
+        // declaration in the `runtime` crate.
+        let registry_index = 7;
+        DispatchError::Module {
+            index: registry_index,
+            error: error as u8,
+            message: None,
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,6 +39,9 @@ pub use string32::String32;
 mod project_domain;
 pub use project_domain::ProjectDomain;
 
+mod error;
+pub use error::RegistryError;
+
 /// Index of a transaction in the chain.
 pub type Index = u32;
 

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -77,7 +77,10 @@ async fn set_checkpoint_without_permission() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(tx_applied.result, Err(DispatchError::Other("")));
+    assert_eq!(
+        tx_applied.result,
+        Err(RegistryError::InsufficientSenderPermissions.into())
+    );
     assert_eq!(updated_project.current_cp, project.current_cp);
     assert_ne!(updated_project.current_cp, new_checkpoint_id);
 }
@@ -101,7 +104,10 @@ async fn fail_to_set_nonexistent_checkpoint() {
     )
     .await;
 
-    assert_eq!(tx_applied.result, Err(DispatchError::Other("")));
+    assert_eq!(
+        tx_applied.result,
+        Err(RegistryError::InexistentCheckpointId.into())
+    );
     let updated_project = client
         .get_project(project.id.clone())
         .await

--- a/runtime/tests/checkpoint_creation.rs
+++ b/runtime/tests/checkpoint_creation.rs
@@ -78,5 +78,8 @@ async fn create_checkpoint_without_parent() {
     )
     .await;
 
-    assert_eq!(tx_applied.result, Err(DispatchError::Other("")))
+    assert_eq!(
+        tx_applied.result,
+        Err(RegistryError::InexistentCheckpointId.into())
+    )
 }

--- a/runtime/tests/registration.rs
+++ b/runtime/tests/registration.rs
@@ -88,7 +88,10 @@ async fn register_project_with_duplicate_id() {
     )
     .await;
 
-    assert_eq!(registration_2.result, Err(DispatchError::Other("")));
+    assert_eq!(
+        registration_2.result,
+        Err(RegistryError::DuplicateProjectId.into())
+    );
 
     let project = client.get_project(message.id).await.unwrap().unwrap();
 
@@ -108,7 +111,10 @@ async fn register_project_with_bad_checkpoint() {
 
     let tx_applied = submit_ok(&client, &alice, message.clone()).await;
 
-    assert_eq!(tx_applied.result, Err(DispatchError::Other("")));
+    assert_eq!(
+        tx_applied.result,
+        Err(RegistryError::InexistentCheckpointId.into())
+    );
 
     let no_project = client.get_project(message.id).await.unwrap();
 


### PR DESCRIPTION
This PR changes uses of `DispatchError::Other` in the registry's runtime to `DispatchError::Module` for a better description of errors that occur in invalid transactions.

Part of a larger effort to refactor how error handling is done on the client.

- [x] Refactor Registry transaction error handling to not use `DispatchError::Other(&'static str)`.
- [x] Create `enum` with Registry transaction failures (with statically generated messages and discriminant values for ease of use when converting to `DispatchError`).
- [ ] Refactor error handling on the client side to reflect the previous changes and allow "richer" errors.
- [ ] ?

I'm still not sure what shape it'll take, but `crate::Client::Error::InvalidTransaction` can be changed to receive the `DispatchError` produced by the a failed transaction in the registry.