### PR TITLE
Create new ProjectDomain type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Upcoming
 --------
 
 ### Breaking changes
+* Make `ProjectDomain` a wrapper of `String32` and only support the "rad" domain.
 * Add `metadata` field to Project, a vector of at most 128 bytes.
 * Drop project fields `description` and `img_url`
 * Rename `Client::submit` to `Client::sign_and_submit_call`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,7 +3497,6 @@ dependencies = [
  "async-trait",
  "futures 0.3.1",
  "hex",
- "lazy_static",
  "pretty_env_logger",
  "radicle-registry-client",
  "sp-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,6 @@ async-std = { version = "1.4", features = ["attributes"] }
 async-trait = "0.1"
 futures = "0.3"
 hex = "0.4.0"
-lazy_static = "1.4"
 pretty_env_logger = "0.3.1"
 structopt = "0.3"
 url = "1.7"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,9 @@ pub use bytes128::Bytes128;
 mod string32;
 pub use string32::String32;
 
+mod project_domain;
+pub use project_domain::ProjectDomain;
+
 /// Index of a transaction in the chain.
 pub type Index = u32;
 
@@ -53,12 +56,6 @@ pub type Balance = u128;
 
 /// The name a project is registered with.
 pub type ProjectName = String32;
-
-/// The domain under which the project's name is registered.
-///
-/// At present, the domain must be `rad`, alhtough others may be allowed in
-/// the future.
-pub type ProjectDomain = String32;
 
 pub type ProjectId = (ProjectName, ProjectDomain);
 

--- a/core/src/project_domain.rs
+++ b/core/src/project_domain.rs
@@ -1,0 +1,151 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::String32;
+use alloc::prelude::v1::*;
+use core::convert::TryFrom;
+use core::str::FromStr;
+
+use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
+
+/// A Project Domain, limited to 32 bytes and to the supported d
+#[derive(Encode, Clone, Debug, Eq, PartialEq)]
+pub struct ProjectDomain(String32);
+
+impl ProjectDomain {
+    /// Build a ProjectDomain from a given string.
+    /// Fails when the given domain is longer than 32 bytes in length or
+    /// if its not yet supported by Radicle.
+    ///
+    /// Currently only supporting the "rad" domain.
+    pub fn from_string(domain: String) -> Result<Self, ProjectDomainError> {
+        if domain == "rad" {
+            Ok(ProjectDomain::rad_domain())
+        } else {
+            Err(ProjectDomainError::NotYetSupported)
+        }
+    }
+
+    pub fn from_string32(domain: String32) -> Result<Self, ProjectDomainError> {
+        Self::from_string(domain.into())
+    }
+
+    pub fn rad_domain() -> ProjectDomain {
+        ProjectDomain(String32::from_str("rad").expect("statically valid"))
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for ProjectDomain {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+/// Possible errors when attempting to build a ProjectDomain.
+#[derive(Encode, Clone, Debug, Eq, PartialEq)]
+pub enum ProjectDomainError {
+    /// The provided domain exceeds the 32 bytes length limit.
+    Inordinate,
+    /// The provided domain is not yet supported by Radicle.
+    NotYetSupported,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ProjectDomainError {}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for ProjectDomainError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+/// Conversion implementations
+
+impl Decode for ProjectDomain {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, CodecError> {
+        let decoded = String32::decode(input)?;
+        ProjectDomain::from_string32(decoded).or_else(|_| {
+            Err(CodecError::from(
+                "Failed to decode an unsupported project domain.",
+            ))
+        })
+    }
+}
+
+impl core::str::FromStr for ProjectDomain {
+    type Err = ProjectDomainError;
+
+    /// Returns an error if the domain is longer than 32 bytes
+    /// or is not supported by radicle.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ProjectDomain::from_string(s.into())
+    }
+}
+
+impl TryFrom<String> for ProjectDomain {
+    type Error = ProjectDomainError;
+
+    /// Returns an error if the domain is longer than 32 bytes
+    /// or is not supported by radicle.
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        ProjectDomain::from_string(value)
+    }
+}
+
+impl From<ProjectDomain> for String {
+    fn from(value: ProjectDomain) -> Self {
+        (value.0).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn radicle_domain() {
+        assert_eq!(
+            ProjectDomain::rad_domain(),
+            ProjectDomain::from_str("rad").unwrap()
+        )
+    }
+
+    #[test]
+    fn from_inordinate_domain() {
+        assert_eq!(
+            ProjectDomain::from_string("rad".repeat(11)),
+            Err(ProjectDomainError::NotYetSupported)
+        )
+    }
+
+    #[test]
+    fn from_unsupported_domain() {
+        assert_eq!(
+            ProjectDomain::from_str("github"),
+            Err(ProjectDomainError::NotYetSupported)
+        )
+    }
+
+    #[test]
+    fn decode_after_encode_is_identity() {
+        let domain = ProjectDomain::rad_domain();
+        let encoded = domain.encode();
+        let decoded = <ProjectDomain>::decode(&mut &encoded[..]).unwrap();
+
+        assert_eq!(domain, decoded)
+    }
+}

--- a/core/src/string32.rs
+++ b/core/src/string32.rs
@@ -16,6 +16,7 @@
 /// `String32` type, and its validation tests.
 use alloc::format;
 use alloc::prelude::v1::*;
+use core::convert::Into;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 
 /// A [String] that is limited to 32 bytes in UTF-8 encoding.
@@ -40,6 +41,12 @@ impl String32 {
         } else {
             Ok(String32(s))
         }
+    }
+}
+
+impl Into<String> for String32 {
+    fn into(self) -> String {
+        self.0
     }
 }
 

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -66,7 +66,7 @@ pub mod store {
         /// # use std::str::FromStr;
         /// let project_id = (
         ///     String32::from_str("name").unwrap(),
-        ///     String32::from_str("domain").unwrap()
+        ///     ProjectDomain::from_str("rad").unwrap()
         /// );
         ///
         /// let key = store::Projects::storage_map_final_key(project_id.clone());

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -61,15 +61,9 @@ pub async fn create_project_with_checkpoint(client: &Client, author: &ed25519::P
 /// characters, and the description and image URL will be alphanumeric strings
 /// with 50 characters.
 pub fn random_register_project_message(checkpoint_id: CheckpointId) -> message::RegisterProject {
-    let name = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(32)
-        .collect::<String>();
-    let domain = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(32)
-        .collect::<String>();
-    let id = (name.parse().unwrap(), domain.parse().unwrap());
+    let name = random_string(32);
+    let domain = ProjectDomain::rad_domain();
+    let id = (name.parse().unwrap(), domain);
 
     message::RegisterProject {
         id,
@@ -80,4 +74,11 @@ pub fn random_register_project_message(checkpoint_id: CheckpointId) -> message::
 
 pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {
     ed25519::Pair::from_string(format!("//{}", value.as_ref()).as_str(), None).unwrap()
+}
+
+pub fn random_string(size: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .collect::<String>()
 }


### PR DESCRIPTION
This new type wraps a String32 with a smart contract that ensures the
project domain is not only at most 32 bytes in length but also that it
is a supported domain by Radicle at this time. For now, we only support
the "rad" domain.

- [x] Create `ProjectDomain` wrapper type
- [x] Implement all useful conversion implementations
- [x] Provide a better error type 
- [x] Add unit tests
- [x] Replace current `ProjectDomain` alias with this new one
- [x] Handle failing `ProjectDomain` and report errors accordingly

## Questions

Q1: Does the domain support need to be case-insensitive? 