### PR TITLE
cli: Add CommandError and eliminate .unwrap()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ version = "0.0.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "derive_more 0.99.2",
  "futures 0.3.1",
  "hex",
  "pretty_env_logger",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ radicle-registry-client = { version = "0.0.0", path = "../client" }
 
 async-std = { version = "1.4", features = ["attributes"] }
 async-trait = "0.1"
+derive_more = "0.99"
 futures = "0.3"
 hex = "0.4.0"
 pretty_env_logger = "0.3.1"


### PR DESCRIPTION
We add `CommandError` as the error for `CommandT::run` and provide `From` instances for client and dispatch errors.

We keep the `CommandError` very basic for now until we have revisited the client and ledger errors.

Closes #176