### PR TITLE
Fix ./scripts/build-client-docs

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -68,8 +68,8 @@ impl Client {
     /// Same as [Client::create] but calls to the client spawn futures in an executor owned by the
     /// client.
     ///
-    /// This makes it possible to call [Future::wait] on the client even if that function is called
-    /// in an event loop of another executor.
+    /// This makes it possible to call block on future in the client even if that function is
+    /// called in an event loop of another executor.
     pub async fn create_with_executor(host: url::Host) -> Result<Self, Error> {
         let backend = backend::RemoteNodeWithExecutor::create(host).await?;
         Ok(Self::new(backend))

--- a/scripts/build-client-docs
+++ b/scripts/build-client-docs
@@ -7,7 +7,9 @@ set -euo pipefail
 cargo doc \
   --no-deps \
   -p radicle-registry-client \
-  -p substrate-primitives \
-  -p sr-io \
-  -p sr-primitives \
+  -p radicle-registry-core \
+  -p sp-core \
+  -p sp-runtime \
+  -p frame-system \
+  -p frame-support \
   "$@"


### PR DESCRIPTION
With the big package renaming on substrate we need to update the script that builds the client documentation

Also fixes an invalid documentation link.