### PR TITLE
Return proper error types bytes128 string32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Upcoming
 --------
 
 ### Breaking changes
+* `String32::from_string` now returns `Result<String32, InordinateStringError>`
+* `Bytes128::from_vec` now returns `Result<Bytes128, InordinateVectorError>`
 * Make `ProjectDomain` a wrapper of `String32` and only support the "rad" domain.
 * Add `metadata` field to Project, a vector of at most 128 bytes.
 * Drop project fields `description` and `img_url`

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,10 +30,10 @@ pub use sp_runtime::DispatchError;
 
 pub mod message;
 
-mod bytes128;
+pub mod bytes128;
 pub use bytes128::Bytes128;
 
-mod string32;
+pub mod string32;
 pub use string32::String32;
 
 mod project_domain;


### PR DESCRIPTION
Closes #185

### Changes

- `Bytes128::from_vec` now returns `Result<Bytes128, InordinateVector>` instead of `Result<Bytes128, String>`
- `String32::from_string` now returns `Result<String32, InordinateString>` instead of `Result<String32, String>`

### Decisions

Initially,  I thought of having an `enum` for each of the types such as `String32Error` and `Bytes128Error` with all the error case possible. I decided to make things simpler and follow the _YAGNI_ principle. To date, the only reason for each of these types to fail to build is if their inputs are too long for their own requirements. Therefore I have both `InordinateString` and `InordinateVector` as a struct with a single field: the input, failing value. That way we can provide useful error messages in a single place too, by implementing `Display`.

