### PR TITLE
Feature/orgs [Part 1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Upcoming
 
 ### Addition
 
+* Add `Client::get_org` and `Client::list_orgs`
+* Add `RegisterOrg` and `UnregisterOrg` messages
 * Add Transaction::hash() function
 * Offline transaction signing with the following new APIs
   * `ClientT::account_nonce()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,9 +4816,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c188479c8b700998829c168d7a4c21032660b0dd2ed87a0b166c85811750740"
 dependencies = [
- "proc-macro2 1.0.7",
+ "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -136,6 +136,64 @@ impl CommandT for ListProjects {
 }
 
 #[derive(StructOpt, Debug, Clone)]
+/// Register an org.
+pub struct RegisterOrg {
+    /// Id of the org to register.
+    id: OrgId,
+}
+
+#[async_trait::async_trait]
+impl CommandT for RegisterOrg {
+    async fn run(&self, command_context: &CommandContext) -> Result<(), CommandError> {
+        let client = &command_context.client;
+
+        let register_org_fut = client
+            .sign_and_submit_message(
+                &command_context.author_key_pair,
+                message::RegisterOrg {
+                    id: self.id.clone(),
+                },
+            )
+            .await?;
+        println!("Registering org...");
+
+        let org_registered = register_org_fut.await?;
+        transaction_applied_ok(&org_registered)?;
+        println!("Org {} is now registered.", self.id);
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug, Clone)]
+/// Unregister an org.
+pub struct UnregisterOrg {
+    /// Id of the org to unregister.
+    id: OrgId,
+}
+
+#[async_trait::async_trait]
+impl CommandT for UnregisterOrg {
+    async fn run(&self, command_context: &CommandContext) -> Result<(), CommandError> {
+        let client = &command_context.client;
+
+        let register_org_fut = client
+            .sign_and_submit_message(
+                &command_context.author_key_pair,
+                message::UnregisterOrg {
+                    id: self.id.clone(),
+                },
+            )
+            .await?;
+        println!("Unregistering org...");
+
+        let org_unregistered = register_org_fut.await?;
+        transaction_applied_ok(&org_unregistered)?;
+        println!("Org {} is now unregistered.", self.id);
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug, Clone)]
 /// Register a project under the default "rad" domain.
 pub struct RegisterProject {
     /// Name of the project to register.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,6 +65,8 @@ impl Args {
 #[derive(StructOpt, Debug, Clone)]
 enum Command {
     ListProjects(ListProjects),
+    RegisterOrg(RegisterOrg),
+    UnregisterOrg(UnregisterOrg),
     RegisterProject(RegisterProject),
     ShowBalance(ShowBalance),
     ShowGenesisHash(ShowGenesisHash),
@@ -92,6 +94,8 @@ async fn run(args: Args) -> Result<(), CommandError> {
 
     match args.command {
         Command::ListProjects(cmd) => cmd.run(&command_context).await,
+        Command::RegisterOrg(cmd) => cmd.run(&command_context).await,
+        Command::UnregisterOrg(cmd) => cmd.run(&command_context).await,
         Command::RegisterProject(cmd) => cmd.run(&command_context).await,
         Command::ShowBalance(cmd) => cmd.run(&command_context).await,
         Command::ShowGenesisHash(cmd) => cmd.run(&command_context).await,

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -87,6 +87,10 @@ pub trait ClientT {
 
     async fn free_balance(&self, account_id: &AccountId) -> Result<Balance, Error>;
 
+    async fn get_org(&self, id: OrgId) -> Result<Option<Org>, Error>;
+
+    async fn list_orgs(&self) -> Result<Vec<OrgId>, Error>;
+
     async fn get_project(&self, id: ProjectId) -> Result<Option<state::Project>, Error>;
 
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error>;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -220,6 +220,24 @@ impl ClientT for Client {
         Ok(account_data.free)
     }
 
+    async fn get_org(&self, id: OrgId) -> Result<Option<Org>, Error> {
+        self.fetch_map_value::<registry::store::Orgs, _, _>(id.clone())
+            .await
+            .map(|maybe_org: Option<state::Org>| maybe_org.map(|org| Org::from(id, org)))
+    }
+
+    async fn list_orgs(&self) -> Result<Vec<OrgId>, Error> {
+        let orgs_prefix = registry::store::Orgs::final_prefix();
+        let keys = self.backend.fetch_keys(&orgs_prefix, None).await?;
+        let mut org_ids: Vec<OrgId> = Vec::with_capacity(keys.len());
+        for key in keys {
+            let org_id = registry::store::Orgs::id_from_key(&key)
+                .expect("Invalid runtime state key. Cannot extract org ID");
+            org_ids.push(org_id)
+        }
+        Ok(org_ids)
+    }
+
     async fn get_project(&self, id: ProjectId) -> Result<Option<state::Project>, Error> {
         self.fetch_map_value::<registry::store::Projects, _, _>(id)
             .await

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -62,6 +62,44 @@ impl Message for message::RegisterProject {
     }
 }
 
+impl Message for message::RegisterOrg {
+    type Result = Result<(), DispatchError>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "OrgRegistered", |event| match event {
+                Event::registry(registry::Event::OrgRegistered(_)) => Some(Ok(())),
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::register_org(self).into()
+    }
+}
+
+impl Message for message::UnregisterOrg {
+    type Result = Result<(), DispatchError>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "OrgUnregistered", |event| match event {
+                Event::registry(registry::Event::OrgUnregistered(_)) => Some(Ok(())),
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::unregister_org(self).into()
+    }
+}
+
 impl Message for message::CreateCheckpoint {
     type Result = Result<CheckpointId, DispatchError>;
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -19,18 +19,23 @@ use crate::DispatchError;
 /// Errors describing failed Registry transactions.
 pub enum RegistryError {
     InexistentCheckpointId = 0,
+    InexistentOrg,
+    DuplicateOrgId,
     DuplicateProjectId,
     InexistentProjectId,
     InsufficientSenderPermissions,
     InexistentParentCheckpoint,
     InexistentInitialProjectCheckpoint,
     InvalidCheckpointAncestry,
+    UnregisterableOrg,
 }
 
 impl From<RegistryError> for &'static str {
     fn from(error: RegistryError) -> &'static str {
         match error {
             RegistryError::InexistentCheckpointId => "The provided checkpoint does not exist",
+            RegistryError::InexistentOrg => "The provided org does not exist",
+            RegistryError::DuplicateOrgId => "An org with a similar ID already exists.",
             RegistryError::DuplicateProjectId => "A project with a similar ID already exists.",
             RegistryError::InexistentProjectId => "Project does not exist",
             RegistryError::InsufficientSenderPermissions => "Sender is not a project member",
@@ -40,6 +45,9 @@ impl From<RegistryError> for &'static str {
             }
             RegistryError::InvalidCheckpointAncestry => {
                 "The provided checkpoint is not a descendant of the project's initial checkpoint."
+            }
+            RegistryError::UnregisterableOrg => {
+                "The provided org is not elibile for unregistration."
             }
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,6 +20,8 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
+
 use sp_core::{ed25519, H256};
 use sp_runtime::traits::BlakeTwo256;
 
@@ -55,5 +57,38 @@ pub type Balance = u128;
 pub type ProjectName = String32;
 
 pub type ProjectId = (ProjectName, ProjectDomain);
+
+pub type OrgId = String32;
+
+/// Org
+///
+/// Different from [state::Org] in which this type gathers
+/// both the id and the other Org fields, respectively stored
+/// as an Org's storage key and data, into one complete type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Org {
+    // Id of an Org.
+    pub id: OrgId,
+
+    /// See [state::Org::account_id]
+    pub account_id: AccountId,
+
+    /// See [state::Org::members]
+    pub members: Vec<AccountId>,
+
+    /// See [state::Org::projects]
+    pub projects: Vec<ProjectName>,
+}
+
+impl Org {
+    pub fn from(id: OrgId, org: state::Org) -> Org {
+        Org {
+            id,
+            account_id: org.account_id,
+            members: org.members,
+            projects: org.projects,
+        }
+    }
+}
 
 pub type CheckpointId = H256;

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -18,8 +18,43 @@
 //! See the README.md for more information on how to document messages.
 extern crate alloc;
 
-use crate::{AccountId, Balance, Bytes128, CheckpointId, ProjectId, H256};
+use crate::{AccountId, Balance, Bytes128, CheckpointId, OrgId, ProjectId, H256};
 use parity_scale_codec::{Decode, Encode};
+
+/// Registers an org on the Radicle Registry with the given ID.
+///
+/// # State changes
+///
+/// If successful, a new [crate::state::Org] with the given properties is added to the state.
+///
+/// [crate::state::Org::members] is initialized with the transaction author as the only member.
+///
+/// [crate::state::Org::account_id] is generated randomly.
+///
+/// # State-dependent validations
+///
+/// An Org with the same ID must not yet exist.
+///
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct RegisterOrg {
+    pub id: OrgId,
+}
+
+/// Unregisters an org on the Radicle Registry with the given ID.
+///
+/// # State changes
+///
+/// If successful, the targeted Org is removed from the state.
+///
+/// # State-dependent validations
+///
+/// The targeted org must exist and have no projects and the
+/// the transaction origin must be its only member.
+///
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct UnregisterOrg {
+    pub id: OrgId,
+}
 
 /// Registers a project on the Radicle Registry with the given ID.
 ///

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -14,11 +14,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! Type definitions for all entities stored in the ledger state.
+
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use sp_runtime::traits::Hash;
 
-use crate::{AccountId, Balance, Bytes128, CheckpointId, Hashing, ProjectId, H256};
+use crate::{AccountId, Balance, Bytes128, CheckpointId, Hashing, ProjectId, ProjectName, H256};
 
 /// A checkpoint defines an immutable state of a project’s off-chain data via a hash.
 ///
@@ -72,7 +73,7 @@ pub struct Project {
     /// ID of the project. The storage key is derived from this value.
     pub id: ProjectId,
 
-    /// Account ID that holds the projecs founds.
+    /// Account ID that holds the projecs funds.
     ///
     /// This is randomly generated and unlike for other accounts there is no private key that
     /// controls this account.
@@ -117,3 +118,40 @@ pub type AccountBalance = Balance;
 ///
 /// Indicies are stored as a map with a key derived from [crate::AccountId].
 pub type Index = u32;
+
+/// # Storage
+///
+/// This type is only used for storage. See [crate::Org] for the
+/// complete Org type to be used everywhere else.
+///
+/// Orgs are stored as a map with the key derived from [crate::Org::id].
+/// The org ID can be extracted from the storage key.
+///
+/// # Invariants
+///
+/// * `account_id` is immutable
+/// * `projects` is a set of all the projects owned by the Org.
+///
+/// # Relevant messages
+///
+/// * [crate::message::RegisterOrg]
+/// * [crate::message::UnregisterOrg]
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct Org {
+    /// Account ID that holds the org funds.
+    ///
+    /// It is randomly generated and, unlike for other accounts,
+    /// there is no private key that controls this account.
+    pub account_id: AccountId,
+
+    /// Set of members of the org. Members are allowed to manage
+    /// the org, its projects, and transfer funds.
+    ///
+    /// It is initialized with the author of the [crate::message::RegisterOrg]
+    /// transaction. It cannot be changed at the moment.
+    pub members: Vec<AccountId>,
+
+    /// Set of all projects owned by the org. Members are allowed to register
+    /// a project by sending a [crate::message::RegisterProject] transaction.
+    pub projects: Vec<ProjectName>,
+}

--- a/runtime/tests/org_registration.rs
+++ b/runtime/tests/org_registration.rs
@@ -1,0 +1,130 @@
+/// Runtime tests implemented with [MemoryClient].
+///
+/// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
+///
+/// The tests in this module concern orgs registration.
+use radicle_registry_client::*;
+use radicle_registry_test_utils::*;
+
+#[async_std::test]
+async fn register_org() {
+    let client = Client::new_emulator();
+    let alice = key_pair_from_string("Alice");
+    let register_org_message = random_register_org_message();
+
+    let tx_applied = submit_ok(&client, &alice, register_org_message.clone()).await;
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+    );
+    assert_eq!(tx_applied.result, Ok(()));
+
+    let has_org = client
+        .list_orgs()
+        .await
+        .unwrap()
+        .iter()
+        .any(|id| *id == register_org_message.id);
+    assert!(has_org, "Registered org not found in orgs list");
+
+    let org: Org = client
+        .get_org(register_org_message.id.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(org.id, register_org_message.id);
+    assert_eq!(org.members, vec![alice.public()]);
+    assert!(org.projects.is_empty());
+}
+
+#[async_std::test]
+async fn register_with_duplicated_org_id() {
+    let client = Client::new_emulator();
+    let alice = key_pair_from_string("Alice");
+    let register_org_message = random_register_org_message();
+
+    let tx_applied_once = submit_ok(&client, &alice, register_org_message.clone()).await;
+    assert_eq!(tx_applied_once.result, Ok(()));
+
+    let tx_applied_twice = submit_ok(&client, &alice, register_org_message.clone()).await;
+    assert_eq!(
+        tx_applied_twice.result,
+        Err(RegistryError::DuplicateOrgId.into())
+    );
+}
+
+#[async_std::test]
+async fn unregister_org() {
+    let client = Client::new_emulator();
+    let alice = key_pair_from_string("Alice");
+    let register_org_message = random_register_org_message();
+
+    let tx_applied = submit_ok(&client, &alice, register_org_message.clone()).await;
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+    );
+    assert_eq!(tx_applied.result, Ok(()));
+
+    let has_org = client
+        .list_orgs()
+        .await
+        .unwrap()
+        .iter()
+        .any(|id| *id == register_org_message.id.clone());
+    assert!(has_org, "Registered org not found in orgs list");
+
+    // Unregister
+    let unregister_org_message = message::UnregisterOrg {
+        id: register_org_message.id.clone(),
+    };
+    let tx_unregister_applied = submit_ok(&client, &alice, unregister_org_message.clone()).await;
+    assert_eq!(tx_unregister_applied.result, Ok(()));
+
+    let org_is_gone = !client
+        .list_orgs()
+        .await
+        .unwrap()
+        .iter()
+        .any(|id| *id == register_org_message.id.clone());
+    assert!(org_is_gone, "Registered org not found in orgs list");
+}
+
+#[async_std::test]
+async fn unregister_org_bad_sender() {
+    let client = Client::new_emulator();
+    let alice = key_pair_from_string("Alice");
+    let register_org_message = random_register_org_message();
+
+    let tx_applied = submit_ok(&client, &alice, register_org_message.clone()).await;
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+    );
+    assert_eq!(tx_applied.result, Ok(()));
+
+    let has_org = client
+        .list_orgs()
+        .await
+        .unwrap()
+        .iter()
+        .any(|id| *id == register_org_message.id.clone());
+    assert!(has_org, "Registered org not found in orgs list");
+
+    // Unregister
+    let unregister_org_message = message::UnregisterOrg {
+        id: register_org_message.id.clone(),
+    };
+    let bad_actor = key_pair_from_string("BadActor");
+    let tx_unregister_applied =
+        submit_ok(&client, &bad_actor, unregister_org_message.clone()).await;
+    assert_eq!(
+        tx_unregister_applied.result,
+        Err(RegistryError::UnregisterableOrg.into())
+    );
+}
+
+// TODO(nuno): Test unregister_org_with_projects once possible.

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -75,8 +75,18 @@ pub fn random_register_project_message(checkpoint_id: CheckpointId) -> message::
     }
 }
 
+pub fn random_register_org_message() -> message::RegisterOrg {
+    message::RegisterOrg {
+        id: random_string32(),
+    }
+}
+
 pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {
     ed25519::Pair::from_string(format!("//{}", value.as_ref()).as_str(), None).unwrap()
+}
+
+pub fn random_string32() -> String32 {
+    String32::from_string(random_string(32)).unwrap()
 }
 
 pub fn random_string(size: usize) -> String {


### PR DESCRIPTION
Closes #194, #195, #198, #212

### Changes

- Implement `Org` type (#194)
- Add `RegisterOrg` message ( #195)
- Add `UnregisterOrg` message (#198)
- Unit test both new messages
- Support `RegisterOrg` and `UnregisterOrg` from the cli (#212)

### Decisions

Regarding the `Org` type, I have opted for `Vec` instead of `HashSet` for the Org members and projects fields for the reason I explain at 72c63a3896eb25c96ace77082abc3c5c921f38e6:

> Note that we opt for Vec for members and projects since substrate
doesn't offer Encode/Decode implementations for HashSet. To be able to
use HashSet we would need to create wrapper types around
HashSet<AccountId> and HashSet<ProjectName> since it's not possible to
implement a trait for a type foreigner to the current crate.

