### PR TITLE
Run end_to_end tests sequentially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,6 +3527,7 @@ dependencies = [
  "radicle-registry-test-utils",
  "rand 0.7.3",
  "sc-rpc-api",
+ "serial_test",
  "sp-core",
  "sp-io",
  "sp-rpc",
@@ -4728,6 +4729,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74862f16557830c73deefde614c906f8af0157e064b64f156e32a0b12d7114c"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.9.0",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c188479c8b700998829c168d7a4c21032660b0dd2ed87a0b166c85811750740"
+dependencies = [
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -92,7 +92,11 @@ Black-box tests for the runtime logic are implemented with the client emulator
 in `runtime/tests/main.rs`.
 
 End-to-end tests that run against a real node are implemented in
-`client/tests/end_to_end.rs`
+`client/tests/end_to_end.rs`.
+
+To run specific tests sequentially as opposed to the parallel default,
+we use the [serial-test](https://crates.io/crates/serial_test) crate, simply
+having to mark the targeted tests with `#[serial]`.
 
 
 Changelog

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -69,3 +69,4 @@ rev = "4c4ee3d5b91c4c825aef4fde2b096f014a89346a"
 [dev-dependencies]
 rand = "0.7.2"
 radicle-registry-test-utils = { path = "../test-utils"}
+serial_test = "0.3.2"

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -3,10 +3,13 @@
 //! Note that chain state is shared between the test runs.
 
 use async_std;
+use serial_test::serial;
+
 use radicle_registry_client::*;
 use radicle_registry_test_utils::*;
 
 #[async_std::test]
+#[serial]
 async fn register_project() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -67,6 +67,7 @@ async fn register_project() {
 }
 
 #[async_std::test]
+#[serial]
 /// Submit a transaction with an invalid genesis hash and expect an error.
 async fn invalid_transaction() {
     let _ = env_logger::try_init();


### PR DESCRIPTION
Closes #214 

Use the [serial_test](https://crates.io/crates/serial_test) crate to mark specific tests to run sequentially instead of in parallel.

On the reasons for this PR, see https://github.com/radicle-dev/radicle-registry/issues/214.