### PR TITLE
Dry id extraction from BlakeTwo128 storage keys #213

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -37,7 +37,7 @@ use parity_scale_codec::{Decode, FullCodec};
 
 use frame_support::storage::generator::{StorageMap, StorageValue};
 use frame_support::storage::StoragePrefixedMap;
-use radicle_registry_runtime::{balances, registry, Runtime};
+use radicle_registry_runtime::{balances, registry, registry::DecodeKey, Runtime};
 
 mod backend;
 mod error;
@@ -231,7 +231,7 @@ impl ClientT for Client {
         let keys = self.backend.fetch_keys(&orgs_prefix, None).await?;
         let mut org_ids: Vec<OrgId> = Vec::with_capacity(keys.len());
         for key in keys {
-            let org_id = registry::store::Orgs::id_from_key(&key)
+            let org_id = registry::store::Orgs::decode_key(&key)
                 .expect("Invalid runtime state key. Cannot extract org ID");
             org_ids.push(org_id)
         }
@@ -249,7 +249,7 @@ impl ClientT for Client {
         let keys = self.backend.fetch_keys(&project_prefix, None).await?;
         let mut project_ids = Vec::with_capacity(keys.len());
         for key in keys {
-            let project_id = registry::store::Projects::id_from_key(&key)
+            let project_id = registry::store::Projects::decode_key(&key)
                 .expect("Invalid runtime state key. Cannot extract project ID");
             project_ids.push(project_id);
         }


### PR DESCRIPTION
Closes #213 

<blockquote>
We can easily dry this, but I'd prefer us to think of a way of making this more reliable. It is rather fragile to manipulate such a critical part of the registry using hardcoded values and methods to extract ids from storage keys. For instance, `key_hash_prefix_length = 16;`. Shall BlakeTwo128 change its output size, this code won't complain but keep compiling, silently.

My suggestion is to create a `BlakeTwo128Decoder` where this is dry and placed within context. It would be even better if the keys specified in the `decl_storage` could automatically pick up (or have to) on this implementation when they have `hasher(blake2_128_concat)` enabled.

Will see what's possible. Let me know if you have any further or different insight.

See [StorageKey](https://substrate.dev/rustdocs/master/sp_storage/struct.StorageKey.html) for possible useful insights.

_Originally posted by @NunoAlexandre in https://github.com/_render_node/MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDM3NjkyMjczMQ==/comments/review_comment_
</blockquote>


### How

Add a `BlakeTwo128KeyDecoder` that provides the following decode function:

``` rust
pub fn decode<V: parity_scale_codec::Decode>(
    // The raw key to be decoded.
    key: &[u8],
    // The substrate storage prefix.
    prefix: [u8; 32],
) -> Result<V, parity_scale_codec::Error> {
```

Decode the key:

``` rust
let org_id = BlakeTwo128KeyDecoder::decode(&key, orgs_prefix)
let project_id = BlakeTwo128KeyDecoder::decode(&key, project_prefix)
```


This is the result of being pragmatic after trying the following described below.

### What I also tried

Regarding the quote above from the linked issue, my aim was to be able to do something like this:

``` rust
impl BlakeTwo128KeyDecoder for store::Projects {}

store::Projects::decode_key(&key);
```

Having such a set up would mean that we could get the `prefix` and the key type (as in StorageMap)` "for free" and thus be able to do the right thing without boilerplate code.

I tried doing so through the following (rust pseudo-code):

``` rust
pub trait BlakeTwo128KeyDecode
where
    Self: StorageMap<K, V>,
{
    fn decode(key: &[u8]) -> Result<V, parity_scale_codec::Error> {
         // Length of BlakeTwo128 output
         let key_hash_prefix_length = 16;
         let key_prefix_length = Self::prefix().len() + key_hash_prefix_length;
         let mut id_bytes = &key[key_prefix_length..];
         V::decode(&mut id_bytes)
    }
}
```

The thing is that `K` and `V` can't be implicitly inferred. Passing those types are parameters to `BlakeTwo128KeyDecode` introduced boilerplate and space for error, and it didn't really help because, in the end, `StorageMap` doesn't provide the `final_prefix()` function needed to make this worth it. I tried doing that using another substrate storage trait that did provide it but then something else was missing (maybe the Key type, I guess).

In conclusion, I think this aim is still something worth achieving but there should be a better way of doing so. Ideally, Substrate would provide such a decode function for storage using a hasher that allows the key to be decoded. I will look into that in my spare time.





