### PR TITLE
Normalize all core::message and cli command params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 ### Breaking changes
 
+* Normalize core::message and cli commands parameters
 * Update `ProjectId`, now alias to `(OrgId, ProjectName)`
 * Drop `ProjectDomain`
 * Update `Project` to the latest spec containing different fields

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -43,7 +43,7 @@ async fn go() -> Result<(), Error> {
         .sign_and_submit_message(
             &alice,
             message::RegisterProject {
-                id: project_id.clone(),
+                project_id: project_id.clone(),
                 checkpoint_id,
                 metadata: Bytes128::random(),
             },

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -112,11 +112,11 @@ pub trait ClientT {
 
     async fn free_balance(&self, account_id: &AccountId) -> Result<Balance, Error>;
 
-    async fn get_org(&self, id: OrgId) -> Result<Option<Org>, Error>;
+    async fn get_org(&self, org_id: OrgId) -> Result<Option<Org>, Error>;
 
     async fn list_orgs(&self) -> Result<Vec<OrgId>, Error>;
 
-    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>, Error>;
+    async fn get_project(&self, project_id: ProjectId) -> Result<Option<Project>, Error>;
 
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error>;
 

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -29,12 +29,14 @@ async fn register_project() {
     .unwrap();
 
     let org_id = random_string32();
-    let register_org_message = message::RegisterOrg { id: org_id.clone() };
+    let register_org_message = message::RegisterOrg {
+        org_id: org_id.clone(),
+    };
     let org_registered_tx = submit_ok(&client, &alice, register_org_message.clone()).await;
     assert_eq!(org_registered_tx.result, Ok(()));
 
     let register_project_message = random_register_project_message(org_id.clone(), checkpoint_id);
-    let project_id = register_project_message.id.clone();
+    let project_id = register_project_message.project_id.clone();
     let tx_applied = submit_ok(&client, &alice, register_project_message.clone()).await;
     assert_eq!(tx_applied.result, Ok(()));
 
@@ -96,17 +98,17 @@ async fn register_org() {
 
     assert_eq!(
         tx_applied.events[0],
-        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+        RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()
     );
     assert_eq!(tx_applied.result, Ok(()));
 
     let opt_org = client
-        .get_org(register_org_message.id.clone())
+        .get_org(register_org_message.org_id.clone())
         .await
         .unwrap();
     assert!(opt_org.is_some(), "Registered org not found in orgs list");
     let org = opt_org.unwrap();
-    assert_eq!(org.id, register_org_message.id);
+    assert_eq!(org.id, register_org_message.org_id);
     assert_eq!(org.members, vec![alice.public()]);
     assert!(org.projects.is_empty());
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -37,7 +37,7 @@ use parity_scale_codec::{Decode, Encode};
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterOrg {
-    pub id: OrgId,
+    pub org_id: OrgId,
 }
 
 /// Unregisters an org on the Radicle Registry with the given ID.
@@ -53,7 +53,7 @@ pub struct RegisterOrg {
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct UnregisterOrg {
-    pub id: OrgId,
+    pub org_id: OrgId,
 }
 
 /// Register a project on the Radicle Registry with the given ID.
@@ -77,7 +77,7 @@ pub struct UnregisterOrg {
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterProject {
     // The id of the project to register.
-    pub id: ProjectId,
+    pub project_id: ProjectId,
 
     /// Initial checkpoint of the project.
     pub checkpoint_id: CheckpointId,

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -108,7 +108,7 @@ decl_module! {
         #[weight = SimpleDispatchInfo::InsecureFreeNormal]
         pub fn register_project(origin, message: message::RegisterProject) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let (org_id, project_name) = message.id.clone();
+            let (org_id, project_name) = message.project_id.clone();
 
             let org = match store::Orgs::get(org_id.clone()) {
                 None => return Err(RegistryError::InexistentOrg.into()),
@@ -123,7 +123,7 @@ decl_module! {
                 return Err(RegistryError::InexistentCheckpointId.into())
             }
 
-            let project_id = message.id.clone();
+            let project_id = message.project_id.clone();
             if store::Projects::get(project_id.clone()).is_some() {
                 return Err(RegistryError::DuplicateProjectId.into());
             };
@@ -145,7 +145,7 @@ decl_module! {
         pub fn register_org(origin, message: message::RegisterOrg) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
-            match store::Orgs::get(message.id.clone()) {
+            match store::Orgs::get(message.org_id.clone()) {
                 None => {},
                 Some(_) => return Err(RegistryError::DuplicateOrgId.into()),
             }
@@ -161,8 +161,8 @@ decl_module! {
                 members: vec![sender],
                 projects: Vec::new(),
             };
-            store::Orgs::insert(message.id.clone(), new_org);
-            Self::deposit_event(Event::OrgRegistered(message.id));
+            store::Orgs::insert(message.org_id.clone(), new_org);
+            Self::deposit_event(Event::OrgRegistered(message.org_id));
             Ok(())
         }
 
@@ -174,12 +174,12 @@ decl_module! {
 
             let sender = ensure_signed(origin)?;
 
-            match store::Orgs::get(message.id.clone()) {
+            match store::Orgs::get(message.org_id.clone()) {
                 None => Err(RegistryError::InexistentOrg.into()),
                 Some(org) => {
                     if can_be_unregistered(org, sender) {
-                        store::Orgs::remove(message.id.clone());
-                        Self::deposit_event(Event::OrgUnregistered(message.id));
+                        store::Orgs::remove(message.org_id.clone());
+                        Self::deposit_event(Event::OrgUnregistered(message.org_id));
                         Ok(())
                     }
                     else {

--- a/runtime/tests/org_registration.rs
+++ b/runtime/tests/org_registration.rs
@@ -16,21 +16,21 @@ async fn register_org() {
 
     assert_eq!(
         tx_applied.events[0],
-        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+        RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()
     );
     assert_eq!(tx_applied.result, Ok(()));
 
     assert!(
-        org_exists(&client, register_org_message.id.clone()).await,
+        org_exists(&client, register_org_message.org_id.clone()).await,
         "Org not found in orgs list"
     );
 
     let org: Org = client
-        .get_org(register_org_message.id.clone())
+        .get_org(register_org_message.org_id.clone())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(org.id, register_org_message.id);
+    assert_eq!(org.id, register_org_message.org_id);
     assert_eq!(org.members, vec![alice.public()]);
     assert!(org.projects.is_empty());
 }
@@ -61,24 +61,24 @@ async fn unregister_org() {
 
     assert_eq!(
         tx_applied.events[0],
-        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+        RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()
     );
     assert_eq!(tx_applied.result, Ok(()));
 
     assert!(
-        org_exists(&client, register_org_message.id.clone()).await,
+        org_exists(&client, register_org_message.org_id.clone()).await,
         "Org not found in orgs list"
     );
 
     // Unregister
     let unregister_org_message = message::UnregisterOrg {
-        id: register_org_message.id.clone(),
+        org_id: register_org_message.org_id.clone(),
     };
     let tx_unregister_applied = submit_ok(&client, &alice, unregister_org_message.clone()).await;
     assert_eq!(tx_unregister_applied.result, Ok(()));
 
     assert!(
-        !org_exists(&client, register_org_message.id.clone()).await,
+        !org_exists(&client, register_org_message.org_id.clone()).await,
         "The org was not expected to exist"
     );
 }
@@ -93,18 +93,18 @@ async fn unregister_org_bad_sender() {
 
     assert_eq!(
         tx_applied.events[0],
-        RegistryEvent::OrgRegistered(register_org_message.id.clone()).into()
+        RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()
     );
     assert_eq!(tx_applied.result, Ok(()));
 
     assert!(
-        org_exists(&client, register_org_message.id.clone()).await,
+        org_exists(&client, register_org_message.org_id.clone()).await,
         "Org not found in orgs list"
     );
 
     // Unregister
     let unregister_org_message = message::UnregisterOrg {
-        id: register_org_message.id.clone(),
+        org_id: register_org_message.org_id.clone(),
     };
     let bad_actor = key_pair_from_string("BadActor");
     let tx_unregister_applied =
@@ -114,7 +114,7 @@ async fn unregister_org_bad_sender() {
         Err(RegistryError::UnregisterableOrg.into())
     );
     assert!(
-        org_exists(&client, register_org_message.id.clone()).await,
+        org_exists(&client, register_org_message.org_id.clone()).await,
         "Org not found in orgs list"
     );
 }
@@ -142,7 +142,7 @@ async fn unregister_org_with_projects() {
 
     // Unregister
     let unregister_org_message = message::UnregisterOrg {
-        id: random_project.org_id.clone(),
+        org_id: random_project.org_id.clone(),
     };
     let tx_unregister_applied = submit_ok(&client, &alice, unregister_org_message.clone()).await;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -53,14 +53,16 @@ pub async fn create_project_with_checkpoint(
     .result
     .unwrap();
 
-    let register_org_message = message::RegisterOrg { id: org_id.clone() };
+    let register_org_message = message::RegisterOrg {
+        org_id: org_id.clone(),
+    };
     submit_ok(&client, &author, register_org_message.clone()).await;
 
     let register_project_message = random_register_project_message(org_id, checkpoint_id);
     submit_ok(&client, &author, register_project_message.clone()).await;
 
     client
-        .get_project(register_project_message.id)
+        .get_project(register_project_message.project_id)
         .await
         .unwrap()
         .unwrap()
@@ -71,7 +73,7 @@ pub async fn create_random_org(client: &Client, author: &ed25519::Pair) -> Org {
     submit_ok(&client, &author, register_org_message.clone()).await;
 
     client
-        .get_org(register_org_message.id)
+        .get_org(register_org_message.org_id)
         .await
         .unwrap()
         .unwrap()
@@ -85,7 +87,7 @@ pub fn random_register_project_message(
     let name = random_string32();
 
     message::RegisterProject {
-        id: (org_id, name),
+        project_id: (org_id, name),
         checkpoint_id,
         metadata: Bytes128::random(),
     }
@@ -93,7 +95,7 @@ pub fn random_register_project_message(
 
 pub fn random_register_org_message() -> message::RegisterOrg {
     message::RegisterOrg {
-        id: random_string32(),
+        org_id: random_string32(),
     }
 }
 


### PR DESCRIPTION
Closes #207 

The goal is that, independently on how an instance of a core::message or cli command is named, the param is unambitious as to its nature and that it's consistently named everywhere. 

For instance, currently, we often have `message.id`, which means nothing on its own. With this PR, that becomes `message.org_id`, `message.project_id`, etc.
