### PR TITLE
Flatten ProjectId usage

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -96,14 +96,14 @@ impl CommandT for ShowProject {
     async fn run(&self, command_context: &CommandContext) -> Result<(), CommandError> {
         let opt_project = command_context
             .client
-            .get_project((self.org_id.clone(), self.project_name.clone()))
+            .get_project(self.project_name.clone(), self.org_id.clone())
             .await?;
 
         let project = match opt_project {
             None => {
                 return Err(CommandError::ProjectNotFound {
-                    org_id: self.org_id.clone(),
                     project_name: self.project_name.clone(),
+                    org_id: self.org_id.clone(),
                 });
             }
             Some(project) => project,
@@ -221,12 +221,12 @@ impl CommandT for RegisterProject {
         let checkpoint_id = transaction_applied_ok(&checkpoint_created)?;
         println!("checkpoint created in block {}", checkpoint_created.block);
 
-        let project_id: ProjectId = (self.org_id.clone(), self.project_name.clone());
         let register_project_fut = client
             .sign_and_submit_message(
                 &command_context.author_key_pair,
                 message::RegisterProject {
-                    project_id,
+                    project_name: self.project_name.clone(),
+                    org_id: self.org_id.clone(),
                     checkpoint_id,
                     metadata: Bytes128::random(),
                 },

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -18,10 +18,8 @@ async fn go() -> Result<(), Error> {
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create(node_host).await?;
 
-    let project_id = (
-        OrgId::from_string("Monadic".to_string()).unwrap(),
-        ProjectName::from_string("radicle-registry".to_string()).unwrap(),
-    );
+    let project_name = ProjectName::from_string("radicle-registry".to_string()).unwrap();
+    let org_id = OrgId::from_string("Monadic".to_string()).unwrap();
 
     // Choose some random project hash and create a checkpoint
     let project_hash = H256::random();
@@ -43,7 +41,8 @@ async fn go() -> Result<(), Error> {
         .sign_and_submit_message(
             &alice,
             message::RegisterProject {
-                project_id: project_id.clone(),
+                project_name: project_name.clone(),
+                org_id: org_id.clone(),
                 checkpoint_id,
                 metadata: Bytes128::random(),
             },
@@ -55,7 +54,7 @@ async fn go() -> Result<(), Error> {
 
     println!(
         "Successfully registered project {}.{}",
-        project_id.0, project_id.1
+        project_name, org_id
     );
     Ok(())
 }

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -116,7 +116,11 @@ pub trait ClientT {
 
     async fn list_orgs(&self) -> Result<Vec<OrgId>, Error>;
 
-    async fn get_project(&self, project_id: ProjectId) -> Result<Option<Project>, Error>;
+    async fn get_project(
+        &self,
+        project_name: ProjectName,
+        org_id: OrgId,
+    ) -> Result<Option<Project>, Error>;
 
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error>;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -238,10 +238,17 @@ impl ClientT for Client {
         Ok(org_ids)
     }
 
-    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>, Error> {
-        self.fetch_map_value::<registry::store::Projects, _, _>(id.clone())
+    async fn get_project(
+        &self,
+        project_name: ProjectName,
+        org_id: OrgId,
+    ) -> Result<Option<Project>, Error> {
+        let project_id = (project_name.clone(), org_id.clone());
+        self.fetch_map_value::<registry::store::Projects, _, _>(project_id.clone())
             .await
-            .map(|maybe_project| maybe_project.map(|project| Project::new(id.0, id.1, project)))
+            .map(|maybe_project| {
+                maybe_project.map(|project| Project::new(project_name, org_id, project))
+            })
     }
 
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error> {

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -48,7 +48,7 @@ impl Message for message::RegisterProject {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "ProjectRegistered", |event| match event {
-                Event::registry(registry::Event::ProjectRegistered(_project_id)) => Some(Ok(())),
+                Event::registry(registry::Event::ProjectRegistered(_, _)) => Some(Ok(())),
                 _ => None,
             }),
             Err(dispatch_error) => Ok(Err(dispatch_error)),
@@ -126,9 +126,11 @@ impl Message for message::SetCheckpoint {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "CheckpointSet", |event| match event {
-                Event::registry(registry::Event::CheckpointSet(_project_id, _checkpoint_id)) => {
-                    Some(Ok(()))
-                }
+                Event::registry(registry::Event::CheckpointSet(
+                    _project_name,
+                    _org_id,
+                    _checkpoint_id,
+                )) => Some(Ok(())),
                 _ => None,
             }),
             Err(dispatch_error) => Ok(Err(dispatch_error)),

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -36,16 +36,18 @@ async fn register_project() {
     assert_eq!(org_registered_tx.result, Ok(()));
 
     let register_project_message = random_register_project_message(org_id.clone(), checkpoint_id);
-    let project_id = register_project_message.project_id.clone();
+    let project_name = register_project_message.project_name.clone();
+    let org_id = register_project_message.org_id.clone();
     let tx_applied = submit_ok(&client, &alice, register_project_message.clone()).await;
     assert_eq!(tx_applied.result, Ok(()));
 
     let project = client
-        .get_project(project_id.clone())
+        .get_project(project_name.clone(), org_id.clone())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(project.clone().id(), project_id.clone());
+    assert_eq!(project.name.clone(), project_name.clone());
+    assert_eq!(project.org_id.clone(), org_id.clone());
     assert_eq!(
         project.current_cp.clone(),
         register_project_message.checkpoint_id
@@ -54,7 +56,7 @@ async fn register_project() {
 
     assert_eq!(
         tx_applied.events[0],
-        RegistryEvent::ProjectRegistered(project_id.clone()).into()
+        RegistryEvent::ProjectRegistered(project_name.clone(), org_id.clone()).into()
     );
 
     let checkpoint = client.get_checkpoint(checkpoint_id).await.unwrap().unwrap();
@@ -66,7 +68,7 @@ async fn register_project() {
 
     assert!(
         client
-            .get_project(project_id.clone())
+            .get_project(project_name.clone(), org_id.clone())
             .await
             .unwrap()
             .is_some(),
@@ -75,12 +77,10 @@ async fn register_project() {
 
     let org: Org = client.get_org(org_id.clone()).await.unwrap().unwrap();
     assert!(
-        org.projects.contains(&project_id.1),
+        org.projects.contains(&project_name),
         format!(
             "Expected project id {} in Org {} with projects {:?}",
-            project_id.1.clone(),
-            project_id.0.clone(),
-            org.projects
+            project_name, org_id, org.projects
         )
     );
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,10 +50,11 @@ pub type AccountId = ed25519::Public;
 /// Balance of an account.
 pub type Balance = u128;
 
+/// The id of a project. Used as storage key.
+pub type ProjectId = (ProjectName, OrgId);
+
 /// The name a project is registered with.
 pub type ProjectName = String32;
-
-pub type ProjectId = (OrgId, ProjectName);
 
 pub type OrgId = String32;
 
@@ -104,12 +105,8 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn id(self) -> ProjectId {
-        (self.org_id, self.name)
-    }
-
     /// Build a [crate::Project] given all its properties obtained from storage.
-    pub fn new(org_id: OrgId, name: ProjectName, project: state::Project) -> Self {
+    pub fn new(name: ProjectName, org_id: OrgId, project: state::Project) -> Self {
         Project {
             name,
             org_id,

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -18,7 +18,7 @@
 //! See the README.md for more information on how to document messages.
 extern crate alloc;
 
-use crate::{AccountId, Balance, Bytes128, CheckpointId, OrgId, ProjectId, H256};
+use crate::{AccountId, Balance, Bytes128, CheckpointId, OrgId, ProjectName, H256};
 use parity_scale_codec::{Decode, Encode};
 
 /// Registers an org on the Radicle Registry with the given ID.
@@ -76,8 +76,11 @@ pub struct UnregisterOrg {
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterProject {
-    // The id of the project to register.
-    pub project_id: ProjectId,
+    // The name of the project to register, unique in the org.
+    pub project_name: ProjectName,
+
+    /// The org in which to register the project.
+    pub org_id: OrgId,
 
     /// Initial checkpoint of the project.
     pub checkpoint_id: CheckpointId,
@@ -116,7 +119,8 @@ pub struct CreateCheckpoint {
 /// The transaction author must be part of the [crate::state::Org::members] of the given project.
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct SetCheckpoint {
-    pub project_id: ProjectId,
+    pub project_name: ProjectName,
+    pub org_id: OrgId,
     pub new_checkpoint_id: CheckpointId,
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -62,7 +62,10 @@ pub async fn create_project_with_checkpoint(
     submit_ok(&client, &author, register_project_message.clone()).await;
 
     client
-        .get_project(register_project_message.project_id)
+        .get_project(
+            register_project_message.project_name,
+            register_org_message.org_id,
+        )
         .await
         .unwrap()
         .unwrap()
@@ -84,10 +87,9 @@ pub fn random_register_project_message(
     org_id: OrgId,
     checkpoint_id: CheckpointId,
 ) -> message::RegisterProject {
-    let name = random_string32();
-
     message::RegisterProject {
-        project_id: (org_id, name),
+        project_name: random_string32(),
+        org_id,
         checkpoint_id,
         metadata: Bytes128::random(),
     }


### PR DESCRIPTION
Doing so improves readability, makes the api more idiomatic and less
obscure, and separates concerns (storage/state and transactions).


### Changes

There are 3 changes here:

- Flatten `ProjectId` usages, so to have two params (`ProjectName` and `OrgId`) instead of one `ProjectId`
- ~~Move`ProjectId` to `state.rs` since it's not only used as the storage key for Projects and checkpoints.~~ (See https://github.com/radicle-dev/radicle-registry/pull/224#issuecomment-587020442)
- Swap `ProjectName` and `OrgId` in `ProjectId`, so to be `(ProjectName, OrgId)`, being thus consistent with all the usages of these two values everywhere in the registry.