### PR TITLE
Remove duplicate type definition in runtime

### DIFF
--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -105,7 +105,10 @@ pub trait ClientT {
     ) -> Result<Response<TransactionApplied<Message_>, Error>, Error>;
 
     /// Fetch the nonce for the given account from the chain state
-    async fn account_nonce(&self, account_id: &AccountId) -> Result<state::Index, Error>;
+    async fn account_nonce(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<state::AccountTransactionIndex, Error>;
 
     /// Return the gensis hash of the chain we are communicating with.
     fn genesis_hash(&self) -> Hash;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -208,7 +208,10 @@ impl ClientT for Client {
         self.backend.get_genesis_hash()
     }
 
-    async fn account_nonce(&self, account_id: &AccountId) -> Result<state::Index, Error> {
+    async fn account_nonce(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<state::AccountTransactionIndex, Error> {
         self.fetch_map_value::<frame_system::AccountNonce<Runtime>, _, _>(*account_id)
             .await
     }

--- a/client/src/transaction.rs
+++ b/client/src/transaction.rs
@@ -20,7 +20,7 @@ use sp_runtime::generic::{Era, SignedPayload};
 use sp_runtime::traits::{Hash as _, SignedExtension};
 
 use crate::{ed25519, message::Message, CryptoPair as _, TxHash};
-use radicle_registry_core::state::Index;
+use radicle_registry_core::state::AccountTransactionIndex;
 use radicle_registry_runtime::{
     Call as RuntimeCall, Hash, Hashing, SignedExtra, UncheckedExtrinsic,
 };
@@ -66,7 +66,7 @@ impl<Message_: Message> Transaction<Message_> {
 /// The data that is required from the blockchain state to create a valid transaction.
 pub struct TransactionExtra {
     /// The nonce of the account that is the transaction author.
-    pub nonce: Index,
+    pub nonce: AccountTransactionIndex,
     pub genesis_hash: Hash,
 }
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -104,7 +104,7 @@ pub type AccountBalance = Balance;
 /// # Storage
 ///
 /// Indicies are stored as a map with a key derived from [crate::AccountId].
-pub type Index = u32;
+pub type AccountTransactionIndex = u32;
 
 /// # Storage
 ///

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,10 +52,6 @@ pub type BlockNumber = u32;
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = ed25519::Signature;
 
-/// The type for looking up accounts. We don't expect more than 4 billion of them, but you
-/// never know...
-pub type AccountIndex = u32;
-
 /// A hash of some data used by the chain.
 ///
 /// Same as [Hashing::Output].
@@ -119,7 +115,7 @@ impl frame_system::Trait for Runtime {
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
     type Lookup = sp_runtime::traits::IdentityLookup<AccountId>;
     /// The index type for storing how many extrinsics an account has signed.
-    type Index = state::Index;
+    type Index = state::AccountTransactionIndex;
     /// The index type for blocks.
     type BlockNumber = BlockNumber;
     /// The type for hashing blocks and tries.


### PR DESCRIPTION
Remove a type definition in the runtime that is already provided by the
`core` crate.