### PR TITLE
ci: Don’t fail CI if bintray upload fails

### DIFF
--- a/ci/run
+++ b/ci/run
@@ -147,5 +147,7 @@ function upload_to_bintray () {
 
 if [[ -n "${BINTRAY_API_KEY:-}" ]]; then
   echo "--- Upload bintray artifacts"
-  upload_to_bintray
+  # We make this optional until the issue with the storage limit is
+  # resolved.
+  upload_to_bintray || true
 fi


### PR DESCRIPTION
As we’re having issues with bintray we’re making it optional on CI temporarily.