### PR TITLE
Add PoW algorithm CLI switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,8 @@ dependencies = [
  "sc-network",
  "sc-service",
  "sc-transaction-pool",
+ "serde",
+ "serde_json",
  "sp-consensus",
  "sp-consensus-pow",
  "sp-core",
@@ -4601,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953"
+checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
  "itoa",
  "ryu",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,6 +21,8 @@ futures = "0.3.1"
 log = "0.4.8"
 parking_lot = "0.9.0"
 rand = "0.7.3"
+serde = "1.0.104"
+serde_json = "1.0.48"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded"] }
 trie-root = "0.15.2"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -18,10 +18,12 @@
 //! Available chain specs
 //! * [dev] for runnning a single node locally and develop against it.
 //! * [local_devnet] for runnning a cluster of three nodes locally.
+use crate::pow_alg_config::PowAlgConfig;
 use radicle_registry_runtime::{
     AccountId, BalancesConfig, GenesisConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use sp_core::{Pair, Public};
+use std::convert::TryFrom;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::ChainSpec<GenesisConfig>;
@@ -57,7 +59,7 @@ pub fn dev() -> ChainSpec {
         None,   // telemetry endpoints
         // protocol_id
         Some("dev"),
-        None, // no properties
+        Some(sc_service::Properties::try_from(PowAlgConfig::Dummy).unwrap()),
         None, // no extensions
     )
 }
@@ -100,7 +102,7 @@ pub fn devnet() -> ChainSpec {
         None, // telemetry endpoints
         // protocol_id
         Some("devnet"),
-        None, // no properties
+        Some(sc_service::Properties::try_from(PowAlgConfig::Dummy).unwrap()),
         None, // no extensions
     )
 }
@@ -114,7 +116,7 @@ pub fn local_devnet() -> ChainSpec {
         None,   // telemetry endpoints
         // protocol_id
         Some("local-devnet"),
-        None, // no properties
+        Some(sc_service::Properties::try_from(PowAlgConfig::Dummy).unwrap()),
         None, // no extensions
     )
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -26,6 +26,7 @@ mod service;
 mod chain_spec;
 mod cli;
 mod command;
+mod pow_alg_config;
 
 pub use sc_cli::{error, VersionInfo};
 

--- a/node/src/pow_alg_config.rs
+++ b/node/src/pow_alg_config.rs
@@ -1,0 +1,64 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use sc_service::{config::Configuration, Properties};
+use std::convert::{TryFrom, TryInto};
+
+/// Configuration of PoW algorithm, can be stored as chain spec property
+#[derive(serde::Deserialize, serde::Serialize)]
+pub enum PowAlgConfig {
+    Dummy,
+}
+
+impl PowAlgConfig {
+    const PROPERTY_KEY: &'static str = "pow_alg";
+}
+
+impl<'a, T> TryFrom<&'a Configuration<T>> for PowAlgConfig {
+    type Error = &'static str;
+
+    fn try_from(config: &'a Configuration<T>) -> Result<Self, Self::Error> {
+        config
+            .chain_spec
+            .as_ref()
+            .ok_or("configuration does not contain chain spec")?
+            .properties()
+            .try_into()
+    }
+}
+
+impl TryFrom<Properties> for PowAlgConfig {
+    type Error = &'static str;
+
+    fn try_from(mut properties: Properties) -> Result<Self, Self::Error> {
+        let pow_alg_str = properties
+            .remove(PowAlgConfig::PROPERTY_KEY)
+            .ok_or("properies do not contain PoW algorithm")?;
+        serde_json::from_value(pow_alg_str).map_err(|_| "PoW algorithm property malformed")
+    }
+}
+
+impl TryFrom<PowAlgConfig> for Properties {
+    type Error = &'static str;
+
+    fn try_from(config: PowAlgConfig) -> Result<Self, Self::Error> {
+        let key = PowAlgConfig::PROPERTY_KEY.to_string();
+        let value = serde_json::to_value(config)
+            .map_err(|_| "failed to serialize PoW algorithm into a property")?;
+        let mut map = Properties::with_capacity(1);
+        map.insert(key, value);
+        Ok(map)
+    }
+}

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -73,10 +73,10 @@ macro_rules! new_full_start {
             let pool = sc_transaction_pool::BasicPool::new(config, std::sync::Arc::new(pool_api));
             Ok(pool)
         })?
-        .with_import_queue(|_config, client, select_chain, _transaction_pool| {
+        .with_import_queue(|config, client, select_chain, _transaction_pool| {
             // [TEMPLATE DIFF] The whole closure is replaced
             let (block_import, import_queue) =
-                node_import_queue!(client, select_chain, inherent_data_providers.clone());
+                node_import_queue!(config, client, select_chain, inherent_data_providers.clone());
             import_setup = Some(block_import);
             Ok(import_queue)
         })?;
@@ -113,10 +113,10 @@ pub fn new_light(config: Configuration<GenesisConfig>)
             Ok(pool)
         })?
         // [TEMPLATE DIFF] Change FPRB queue to regular one
-        .with_import_queue(|_config, client, select_chain, _transaction_pool| {
+        .with_import_queue(|config, client, select_chain, _transaction_pool| {
                 // [TEMPLATE DIFF] The whole closure is replaced
                 let (_, import_queue) =
-                    node_import_queue!(client, select_chain, inherent_data_providers.clone());
+                    node_import_queue!(config, client, select_chain, inherent_data_providers.clone());
                 Ok(import_queue)
             }
         )?

--- a/node/src/service_customization.rs
+++ b/node/src/service_customization.rs
@@ -18,6 +18,10 @@
 /// The new_full node import building function body
 macro_rules! new_full {
     ($config:expr) => {{
+        use crate::pow_alg_config::PowAlgConfig;
+        use std::convert::TryFrom;
+
+        let pow_alg = PowAlgConfig::try_from(&$config)?;
         let (builder, import_setup, inherent_data_providers) = new_full_start!($config);
         let block_import = import_setup.expect("No import setup set for miner");
 
@@ -30,31 +34,62 @@ macro_rules! new_full {
             transaction_pool: service.transaction_pool(),
         };
 
+        match pow_alg {
+            PowAlgConfig::Dummy => start_mine!(
+                block_import,
+                service,
+                proposer,
+                inherent_data_providers,
+                crate::dummy_pow::DummyPow
+            ),
+        }
+        Ok(service)
+    }};
+}
+
+/// Start mining on full node
+macro_rules! start_mine {
+    ($block_import:expr, $service:expr, $proposer:expr, $inherent_data_providers:expr, $pow_alg:expr) => {{
         sc_consensus_pow::start_mine(
-            block_import,
-            service.client(),
-            crate::dummy_pow::DummyPow,
-            proposer,
+            $block_import,
+            $service.client(),
+            $pow_alg,
+            $proposer,
             None,
             0,
-            service.network(),
+            $service.network(),
             std::time::Duration::new(2, 0),
-            service.select_chain(),
-            inherent_data_providers,
+            $service.select_chain(),
+            $inherent_data_providers,
             sp_consensus::AlwaysCanAuthor,
         );
-
-        Ok(service)
     }};
 }
 
 /// The node with_import_queue closure body
 macro_rules! node_import_queue {
-    ($client:expr, $select_chain:expr, $inherent_data_providers:expr) => {{
+    ($config:expr, $client:expr, $select_chain:expr, $inherent_data_providers:expr) => {{
+        use crate::pow_alg_config::PowAlgConfig;
+        use std::convert::TryFrom;
+
+        match PowAlgConfig::try_from($config)? {
+            PowAlgConfig::Dummy => node_import_queue_for_pow_alg!(
+                $client,
+                $select_chain,
+                $inherent_data_providers,
+                crate::dummy_pow::DummyPow
+            ),
+        }
+    }};
+}
+
+/// The node with_import_queue closure body when PoW algorithm is known
+macro_rules! node_import_queue_for_pow_alg {
+    ($client:expr, $select_chain:expr, $inherent_data_providers:expr, $pow_alg:expr) => {{
         let pow_block_import = sc_consensus_pow::PowBlockImport::new(
             $client.clone(),
             $client,
-            crate::dummy_pow::DummyPow,
+            $pow_alg,
             0,
             $select_chain,
             $inherent_data_providers,
@@ -62,7 +97,7 @@ macro_rules! node_import_queue {
         let block_import = Box::new(pow_block_import);
         let import_queue = sc_consensus_pow::import_queue(
             block_import.clone(),
-            crate::dummy_pow::DummyPow,
+            $pow_alg,
             $inherent_data_providers,
         )?;
         (block_import, import_queue)


### PR DESCRIPTION
This is the first part of https://github.com/radicle-dev/radicle-registry/issues/231: add the PoW algorithm switch mechanism triggerable by the `--dev` CLI flag. Now it provides only 1 option, but adding another one becames trivial.