### PR TITLE
Feature/transaction fees

### DIFF
--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -122,6 +122,8 @@ pub struct SetCheckpoint {
     pub project_name: ProjectName,
     pub org_id: OrgId,
     pub new_checkpoint_id: CheckpointId,
+
+    pub bid: Balance
 }
 
 /// Transfer funds from an org account to an account.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -61,6 +61,8 @@ pub type EventRecord = frame_system::EventRecord<Event, Hash>;
 
 pub mod registry;
 
+pub mod transaction_fee;
+
 pub use pallet_balances as balances;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -255,7 +255,7 @@ decl_module! {
                     if !org.members.contains(&sender) {
                         return Err(RegistryError::InsufficientSenderPermissions.into())
                     }
-                    charge_fee(TransactionFee::Tip(123), &sender);
+                    charge_fee(TransactionFee::Tip(message.bid - TransactionFee::BaseFee.balance()), &sender);
 
                     state::Project {
                         current_cp: message.new_checkpoint_id,

--- a/runtime/src/transaction_fee.rs
+++ b/runtime/src/transaction_fee.rs
@@ -1,0 +1,78 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Balance;
+
+use frame_support::traits::WithdrawReason;
+
+
+/// This module models our Transaction Fee setup.
+/// TODO(nuno): enrich these module docs.
+
+
+
+/// TransactionFee
+enum TransactionFee {
+    /// BaseFee is a fee paid is essentially an entry fee
+    /// for the transaction into the network.
+    BaseFee,
+
+    /// Tip is a an amount indicated by the transaction author
+    /// used to gain their transaction priority.
+    Tip(Balance)
+}
+
+impl TransactionFee {
+    fn to_withdraw_reason(self) -> WithdrawReason {
+        match self {
+            TransactionFee::BaseFee => WithdrawReason::TransactionPayment,
+            TransactionFee::Tip(_) => WithdrawReason::Tip,
+        }
+    }
+
+    fn balance(self) -> Balance {
+        match self {
+            TransactionFee::BaseFee => 1,
+            TransactionFee::Tip(tip) => tip
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::Rng;
+
+
+    #[test]
+    fn withdraw_reason() {
+        assert_eq!(TransactionFee::BaseFee.to_withdraw_reason(), WithdrawReason::TransactionPayment);
+        assert_eq!(TransactionFee::Tip(123).to_withdraw_reason(), WithdrawReason::Tip);
+    }
+
+    #[test]
+    fn base_fee_balance() {
+        assert_eq!(TransactionFee::BaseFee.balance(), 1);
+    }
+
+    #[test]
+    fn tip_balance() {
+        for _ in 0 .. 50 {
+            let random_tip: Balance = rand::thread_rng().gen();
+            assert_eq!(TransactionFee::Tip(random_tip).balance(), random_tip);
+        }
+    }
+}

--- a/runtime/src/transaction_fee.rs
+++ b/runtime/src/transaction_fee.rs
@@ -49,7 +49,7 @@ impl TransactionFee {
         }
     }
 
-    fn balance(&self) -> Balance {
+    pub fn balance(&self) -> Balance {
         match self {
             TransactionFee::BaseFee => 1,
             TransactionFee::Tip(tip) => *tip

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -42,9 +42,10 @@ async fn set_checkpoint() {
     )
     .await;
 
+    // Test that the base fee (1 RAD) + Tip of 123 were withdrew.
     assert_eq!(
         initial_balance - client.free_balance(&author.public()).await.unwrap(),
-        3
+        124
     );
 
     let new_project = client

--- a/runtime/tests/checkpoing_setting.rs
+++ b/runtime/tests/checkpoing_setting.rs
@@ -38,14 +38,15 @@ async fn set_checkpoint() {
             project_name: project.name,
             org_id: project.org_id,
             new_checkpoint_id,
+            bid: 300
         },
     )
     .await;
 
-    // Test that the base fee (1 RAD) + Tip of 123 were withdrew.
+    // Test that the `bid` provided above was withdrew.
     assert_eq!(
         initial_balance - client.free_balance(&author.public()).await.unwrap(),
-        124
+        300
     );
 
     let new_project = client
@@ -86,6 +87,7 @@ async fn set_checkpoint_without_permission() {
             project_name: project.name,
             org_id: project.org_id,
             new_checkpoint_id,
+            bid: 10,
         },
     )
     .await;
@@ -120,6 +122,7 @@ async fn fail_to_set_nonexistent_checkpoint() {
             project_name: project.name,
             org_id: project.org_id,
             new_checkpoint_id: garbage,
+            bid: 10,
         },
     )
     .await;
@@ -185,6 +188,7 @@ async fn set_fork_checkpoint() {
             project_name: project.name,
             org_id: project.org_id,
             new_checkpoint_id: forked_checkpoint_id,
+            bid: 10,
         },
     )
     .await;


### PR DESCRIPTION
This PR is a draft, showing how we could implement our tx fee pipeline, where a `bid` field is being added to the `message::SetCheckpoint` and consumed in the corresponding `set_checkpoint` function in the `runtime::registry`.

For the sake of clarity, the idea is:

1. A user submits a tx with a `bid`
2. The registry charges the fees and uses the remainder as a tip
3. The withdrew amounts will later be transferred to some other account with a small burn

This draft PR addresses 1. and 2. for now, but only touching the `message::SetCheckpoint` and the `runtime > tests > checkpoint_setting.rs > set_checkpoint`.

You can test that specific test by running:

``` bash
cargo test -p radicle-registry-runtime set_checkpoint -- --exact
```

### Feedback request

Since [our requirements](https://radicle.community/t/transaction-fees-on-the-registry-requirements-flows-plan-and-questions/139) are such that we need control over who pays the fees, per transaction, and given the overall tx fee design we want to achieve, opting for a custom implementation over using the default substrate way is preferred.

Now, since going custom means more ways of doing it, I appreciate your early feedback.

I have left already some comments below to guide it. 

Some open question I have and want to have addresses in this draft:

- Where to place the `bid` field (See https://github.com/radicle-dev/radicle-registry/pull/240#discussion_r386267919)
- Do we charge the `base_fee` and the `tip` separately? See https://github.com/radicle-dev/radicle-registry/pull/240#discussion_r386279245 and https://github.com/radicle-dev/radicle-registry/pull/240#discussion_r386280733

