### PR TITLE
Feature/transaction fees [Part 1]

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -23,6 +23,7 @@ pub enum RegistryError {
     DuplicateOrgId,
     DuplicateProjectId,
     InexistentProjectId,
+    InsufficientBid,
     InsufficientSenderPermissions,
     InexistentParentCheckpoint,
     InexistentInitialProjectCheckpoint,
@@ -38,6 +39,9 @@ impl From<RegistryError> for &'static str {
             RegistryError::DuplicateOrgId => "An org with a similar ID already exists.",
             RegistryError::DuplicateProjectId => "A project with a similar ID already exists.",
             RegistryError::InexistentProjectId => "Project does not exist",
+            RegistryError::InsufficientBid => {
+                "The provided bid is insufficient to cover all mandatory fees."
+            }
             RegistryError::InsufficientSenderPermissions => "Sender is not a project member",
             RegistryError::InexistentParentCheckpoint => "Parent checkpoint does not exist",
             RegistryError::InexistentInitialProjectCheckpoint => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,9 @@ pub type Hashing = BlakeTwo256;
 /// Each account has an associated [message::AccountBalance] and [message::Index].
 pub type AccountId = ed25519::Public;
 
-/// Balance of an account.
+/// The non-negative balance of anything storing the amount of currency.
+/// It can be used to represent the value of anything describing an amount,
+/// e.g. an account balance, the value of a fee, etc.
 pub type Balance = u128;
 
 /// The id of a project. Used as storage key.

--- a/runtime/src/fees/bid.rs
+++ b/runtime/src/fees/bid.rs
@@ -1,0 +1,65 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Balance};
+use crate::fees::{BaseFee, Fee, Tip};
+use frame_support::dispatch::DispatchError;
+
+/// Bid
+///
+/// A Bid is an offer defined by a transaction author for the
+/// registry to process that transaction. The bid should cover
+/// all mandatory fees. The remainder left after deducting the
+/// mandatory fees is used as a tip, which will grant priority
+/// to the transaction in question accordingly.
+pub struct Bid {
+    base_fee: BaseFee,
+    tip: Tip
+}
+
+impl Bid {
+    /// Create a Bid with the given `bid`.
+    /// Fail when `bid` is insufficient to cover all the
+    /// mandatory fees, now being the `base_fee` alone.
+    pub fn new(bid: Balance) -> Result<Self, InvalidBid> {
+        let base_fee = BaseFee{};
+        let base_fee_value = base_fee.value();
+        if bid < base_fee_value {
+            return Err(InvalidBid::Insufficient)
+        }
+        Ok(
+            Self {
+                base_fee,
+                tip: Tip(bid - base_fee_value),
+            }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InvalidBid {
+    /// The bid is insufficient to cover all mandatory costs.
+    Insufficient,
+}
+
+impl From<InvalidBid> for DispatchError {
+    fn from(error: InvalidBid) -> Self {
+        DispatchError::Module {
+            index: 42,
+            error: error as u8,
+            message: None,
+        }
+    }
+}

--- a/runtime/src/fees/bid.rs
+++ b/runtime/src/fees/bid.rs
@@ -13,53 +13,63 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Balance};
 use crate::fees::{BaseFee, Fee, Tip};
-use frame_support::dispatch::DispatchError;
+use crate::Balance;
 
 /// Bid
 ///
-/// A Bid is an offer defined by a transaction author for the
-/// registry to process that transaction. The bid should cover
+/// A Bid is an offer defined by transaction authors for the
+/// registry to process their transactions. The bid should cover
 /// all mandatory fees. The remainder left after deducting the
 /// mandatory fees is used as a tip, which will grant priority
-/// to the transaction in question accordingly.
+/// to the transaction in question accordingly to its value.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Bid {
-    base_fee: BaseFee,
-    tip: Tip
+    pub base_fee: BaseFee,
+    pub tip: Tip,
 }
 
 impl Bid {
     /// Create a Bid with the given `bid`.
     /// Fail when `bid` is insufficient to cover all the
     /// mandatory fees, now being the `base_fee` alone.
-    pub fn new(bid: Balance) -> Result<Self, InvalidBid> {
-        let base_fee = BaseFee{};
-        let base_fee_value = base_fee.value();
-        if bid < base_fee_value {
-            return Err(InvalidBid::Insufficient)
-        }
-        Ok(
-            Self {
-                base_fee,
-                tip: Tip(bid - base_fee_value),
-            }
-        )
+    pub fn new(bid: Balance) -> Option<Self> {
+        let base_fee = BaseFee;
+        bid.checked_sub(base_fee.value()).map(|remainder| Self {
+            base_fee,
+            tip: Tip(remainder),
+        })
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum InvalidBid {
-    /// The bid is insufficient to cover all mandatory costs.
-    Insufficient,
-}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::Rng;
 
-impl From<InvalidBid> for DispatchError {
-    fn from(error: InvalidBid) -> Self {
-        DispatchError::Module {
-            index: 42,
-            error: error as u8,
-            message: None,
+    #[test]
+    fn invalid_bid_insufficient() {
+        // The bid is insufficient to cover all mandatory fees.
+        assert_eq!(Bid::new(0), None);
+    }
+
+    #[test]
+    fn valid_bid_just_enough() {
+        // The bid is just enough to cover the mandatory base fee,
+        // leaving a tip of 0 left.
+        let bid = Bid::new(BaseFee.value()).unwrap();
+        assert_eq!(bid.base_fee.value(), 1);
+        assert_eq!(bid.tip.value(), 0);
+    }
+
+    #[test]
+    fn valid_bid_random() {
+        for _ in 0..50 {
+            // Generate a random bid between 1 and 9999.
+            let random_bid: Balance = rand::thread_rng().gen_range(1, 10000);
+            let bid = Bid::new(random_bid).unwrap();
+            assert_eq!(bid.base_fee.value(), 1);
+            assert_eq!(bid.tip.value(), random_bid - BaseFee.value())
         }
     }
 }

--- a/runtime/src/fees/mod.rs
+++ b/runtime/src/fees/mod.rs
@@ -47,3 +47,29 @@ impl Fee for Tip {
         WithdrawReason::Tip
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::Rng;
+
+
+    #[test]
+    fn withdraw_reason() {
+        assert_eq!(BaseFee{}.withdraw_reason(), WithdrawReason::TransactionPayment);
+        assert_eq!(Tip(123).withdraw_reason(), WithdrawReason::Tip);
+    }
+
+    #[test]
+    fn base_fee_value() {
+        assert_eq!(BaseFee{}.value(), 1);
+    }
+
+    #[test]
+    fn tip_value() {
+        for _ in 0 .. 50 {
+            let random_tip: Balance = rand::thread_rng().gen();
+            assert_eq!(Tip(random_tip).value(), random_tip);
+        }
+    }
+}

--- a/runtime/src/fees/mod.rs
+++ b/runtime/src/fees/mod.rs
@@ -17,10 +17,11 @@ use crate::Balance;
 use frame_support::traits::WithdrawReason;
 
 mod bid;
+mod payment;
 
 pub trait Fee {
     fn value(&self) -> Balance;
-    fn withdraw_reason() -> WithdrawReason;
+    fn withdraw_reason(&self) -> WithdrawReason;
 }
 
 #[derive(Clone, Debug)]
@@ -30,7 +31,7 @@ impl Fee for BaseFee {
         1
     }
 
-    fn withdraw_reason() -> WithdrawReason {
+    fn withdraw_reason(&self) -> WithdrawReason {
         WithdrawReason::TransactionPayment
     }
 }
@@ -42,7 +43,7 @@ impl Fee for Tip {
         self.0
     }
 
-    fn withdraw_reason() -> WithdrawReason {
+    fn withdraw_reason(&self) -> WithdrawReason {
         WithdrawReason::Tip
     }
 }

--- a/runtime/src/fees/mod.rs
+++ b/runtime/src/fees/mod.rs
@@ -1,0 +1,48 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Balance;
+use frame_support::traits::WithdrawReason;
+
+mod bid;
+
+pub trait Fee {
+    fn value(&self) -> Balance;
+    fn withdraw_reason() -> WithdrawReason;
+}
+
+#[derive(Clone, Debug)]
+pub struct BaseFee;
+impl Fee for BaseFee {
+    fn value(&self) -> Balance {
+        1
+    }
+
+    fn withdraw_reason() -> WithdrawReason {
+        WithdrawReason::TransactionPayment
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Tip(Balance);
+impl Fee for Tip {
+    fn value(&self) -> Balance {
+        self.0
+    }
+
+    fn withdraw_reason() -> WithdrawReason {
+        WithdrawReason::Tip
+    }
+}

--- a/runtime/src/fees/mod.rs
+++ b/runtime/src/fees/mod.rs
@@ -13,18 +13,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Fee module
+//!
+//! This crate defines all things fees:
+//! * the types of fees supported by the registry
+//! * the [crate::fees::bid] module that abstracts the concept of bid.
+//! * the [crate::fees::payment] module where the withdrawing of fees takes place.
+
 use crate::Balance;
 use frame_support::traits::WithdrawReason;
 
-mod bid;
-mod payment;
+pub mod bid;
+pub mod payment;
 
 pub trait Fee {
+    /// The associated [crate::Balance].
     fn value(&self) -> Balance;
+
+    /// The associated [frame_support::traits::WithdrawReason].
     fn withdraw_reason(&self) -> WithdrawReason;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BaseFee;
 impl Fee for BaseFee {
     fn value(&self) -> Balance {
@@ -36,7 +46,7 @@ impl Fee for BaseFee {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Tip(Balance);
 impl Fee for Tip {
     fn value(&self) -> Balance {
@@ -51,25 +61,18 @@ impl Fee for Tip {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::Rng;
-
 
     #[test]
     fn withdraw_reason() {
-        assert_eq!(BaseFee{}.withdraw_reason(), WithdrawReason::TransactionPayment);
+        assert_eq!(
+            BaseFee.withdraw_reason(),
+            WithdrawReason::TransactionPayment
+        );
         assert_eq!(Tip(123).withdraw_reason(), WithdrawReason::Tip);
     }
 
     #[test]
     fn base_fee_value() {
-        assert_eq!(BaseFee{}.value(), 1);
-    }
-
-    #[test]
-    fn tip_value() {
-        for _ in 0 .. 50 {
-            let random_tip: Balance = rand::thread_rng().gen();
-            assert_eq!(Tip(random_tip).value(), random_tip);
-        }
+        assert_eq!(BaseFee.value(), 1);
     }
 }

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -13,25 +13,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::AccountId;
-use crate::fees::Fee;
+use crate::{fees::Fee, AccountId};
 use frame_support::traits::{Currency, ExistenceRequirement};
 
 /// Pay a given fee by withdrawing it from the `payee` account
-/// and transfering it, with a small burn, to <another account> (TODO(nuno)).
+/// and transfering it, with a small burn, to the block author.
 pub fn pay_fee(fee: impl Fee, payee: &AccountId) {
     // 1. Withdraw from payee
     let _negative_imbalance = <crate::Balances as Currency<_>>::withdraw(
         payee,
         fee.value(),
         fee.withdraw_reason().into(),
-        ExistenceRequirement::KeepAlive
+        ExistenceRequirement::KeepAlive,
     );
-    // 2. Transfer to ??? TODO(nuno)
+    // 2. TODO(nuno) Transfer to the block author. Will be done in a following PR.
 }
 
 /// The burn associated with the payment of a fee.
-/// When a fee is withdrew, it is then transfered to another account.
-/// We apply a small burn on that transfer to increase the value of
-/// our currency.
-const _FEE_PAYMENT_BURN: f64 = 0.001;
+/// When a tx fee is withdrew, it is then transfered to the block author.
+/// We apply a small burn on that transfer to increase the value of our
+/// currency. We will burn this percentage and then floor to go back to Balance.
+const _FEE_PAYMENT_BURN: f64 = 0.01;

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -1,0 +1,37 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::AccountId;
+use crate::fees::Fee;
+use frame_support::traits::{Currency, ExistenceRequirement};
+
+/// Pay a given fee by withdrawing it from the `payee` account
+/// and transfering it, with a small burn, to <another account> (TODO(nuno)).
+pub fn pay_fee(fee: impl Fee, payee: &AccountId) {
+    // 1. Withdraw from payee
+    let _negative_imbalance = <crate::Balances as Currency<_>>::withdraw(
+        payee,
+        fee.value(),
+        fee.withdraw_reason().into(),
+        ExistenceRequirement::KeepAlive
+    );
+    // 2. Transfer to ??? TODO(nuno)
+}
+
+/// The burn associated with the payment of a fee.
+/// When a fee is withdrew, it is then transfered to another account.
+/// We apply a small burn on that transfer to increase the value of
+/// our currency.
+const _FEE_PAYMENT_BURN: f64 = 0.001;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -61,6 +61,8 @@ pub type EventRecord = frame_system::EventRecord<Event, Hash>;
 
 pub mod registry;
 
+pub mod fees;
+
 pub use pallet_balances as balances;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know


### PR DESCRIPTION
## What

In #240, I show how we could implement our own custom fee payment setup. This PR is a first and clean iteration of the emerging ideas after playing around and suggesting the draft.

It introduces a sub crate `runtime::fees` which contains the following modules:

- `runtime::fees` - The basic types to support the notion of `Fee` 
- `runtime::fees::bid`- A module dedicated to modelling and constructing a `Bid`
- `runtime::fees::payment` - A module dedicated to the processing the payment of fees.


### Usage

Looking at the bare example at #240, these new items here introduced could be used as follows:


``` rust
// Create a `Bid` from a raw bid (Balance) value defined by the user in a core::message
let bid = fees::bid::Bid::new(message.bid)?;

// Pay the base_fee
fees::payment::pay_fee(bid.base_fee, &sender);

// Pay the tip
fees::payment::pay_fee(bid.tip, &sender);
```

### Decisions

1. `Bid`
I decided to create the `Bid` type to fully capture what it means. A bid, from the user perspective, is a total amount they indicate that is meant to cover all mandatory fees and the rest to be used as a tip. Therefore, I liked to have that captured in a type. Having this type also grants us the calculation breakdown is done in a single place, instead of having us decrementing value to the entry `bid: Balance` every time we want to pay a fee. This approach also makes this breakdown unit-testable.

2. `Fee` trait
Each fee has a `value` and a `withdraw_reason` associated. `BaseFee` has a fixed value, `Tip` has a calculated one in the moment `Bid` is created. `BaseFee` has `WithdrawReason::TransactionPayment ` as withdraw reason, `Tip` has `WithdrawReason::Tip`. By having this abstraction, we can easily add more `Fee` types without changing the function withdrawing them (`fees::payment::pay_fee`). It also allows us, for instance, to make `Bid` a fee itself, where it'd calculate all of its inner fees and where the reason would be `WithdrawReasons` (that type would need to be changed but the idea still stands): `WithdrawReason::Tip | WithdrawReason::TransactionPayment `.

3. The breakdown into small modules
I am having some difficulty digesting the long modules we have at the moment, that gather _a lot_ of different matters. For peace of mind, I separated the three concepts in 3 different modules. I am open to rethinking it, but I'd appreciate if we could consider moving towards this approach which is not meant to go to the other extreme.
