### PR TITLE
Improve logging output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.42",
 ]
 
 [[package]]
@@ -1618,7 +1618,7 @@ dependencies = [
  "log 0.3.9",
  "mime",
  "num_cpus",
- "time",
+ "time 0.1.42",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -1643,7 +1643,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "rustc_version",
- "time",
+ "time 0.1.42",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor 0.1.10",
@@ -1672,7 +1672,7 @@ dependencies = [
  "itoa",
  "log 0.4.8",
  "pin-project",
- "time",
+ "time 0.1.42",
  "tokio 0.2.11",
  "tower-service",
  "want 0.3.0",
@@ -3517,6 +3517,7 @@ dependencies = [
  "blake3",
  "ctrlc",
  "derive_more 0.15.0",
+ "env_logger 0.7.1",
  "exit-future 0.1.4",
  "futures 0.3.4",
  "log 0.4.8",
@@ -3541,6 +3542,7 @@ dependencies = [
  "sp-runtime",
  "sp-transaction-pool",
  "structopt",
+ "time 0.2.7",
  "tokio 0.2.11",
  "trie-root",
 ]
@@ -4035,7 +4037,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "structopt",
- "time",
+ "time 0.1.42",
  "tokio 0.2.11",
 ]
 
@@ -5524,6 +5526,40 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "time"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3043ac959c44dccc548a57417876c8fe241502aed69d880efc91166c02717a93"
+dependencies = [
+ "libc",
+ "rustversion",
+ "time-macros",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ only the `devnet` chain is available.
 
 For more information use the `--help` flag.
 
+### Logging
+
+The node prints logs to stdout in the following format
+
+~~~
+<local time> <level> <target> <msg>
+~~~
+
+You can adjust the global log level and the log level for specific targets with
+the [`RUST_LOG` environment variable][rust-log-docs].
+
+[rust-log-docs]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
+
 ### Dev Mode
 
 In development mode the node runs an isolated network with only the node as a block miner

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
 
 blake3 = "0.2.1"
 derive_more = "0.15.0"
+env_logger = "0.7"
 exit-future = "0.1.4"
 futures = "0.3.1"
 log = "0.4.8"
@@ -26,6 +27,7 @@ serde = "1.0.104"
 serde_json = "1.0.48"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded"] }
+time = "0.2"
 trie-root = "0.15.2"
 
 [dependencies.ctrlc]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -24,6 +24,7 @@ pub fn run(version: VersionInfo) -> error::Result<()> {
     let opt = sc_cli::from_args::<Cli>(&version);
 
     let config = sc_service::Configuration::new(&version);
+    crate::logger::init();
 
     match opt.subcommand {
         Some(subcommand) => sc_cli::run_subcommand(

--- a/node/src/logger.rs
+++ b/node/src/logger.rs
@@ -1,0 +1,53 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Provides [init] to initialize our custom logger.
+use env_logger::fmt::Color;
+use std::io::Write as _;
+
+/// Initializes [env_logger] using the `RUST_LOG` environment variables and our custom formatter.
+pub fn init() {
+    env_logger::Builder::from_default_env()
+        .format(format_record)
+        .target(env_logger::Target::Stdout)
+        .init();
+}
+
+fn format_record(
+    formatter: &mut env_logger::fmt::Formatter,
+    record: &log::Record,
+) -> std::io::Result<()> {
+    let time = time::OffsetDateTime::now_local();
+
+    let context = format!(
+        "{time}.{ms:03} {level:<5} {target}",
+        time = time.format("%H:%M:%S"),
+        ms = time.millisecond(),
+        target = record.target(),
+        level = record.level(),
+    );
+
+    writeln!(
+        formatter,
+        "{context}  {msg}",
+        context = formatter
+            .style()
+            // Using black with `set_intense(true)` results in grey output.
+            .set_color(Color::Black)
+            .set_intense(true)
+            .value(context),
+        msg = record.args()
+    )
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -25,6 +25,7 @@ mod service;
 mod chain_spec;
 mod cli;
 mod command;
+mod logger;
 mod pow;
 
 pub use sc_cli::{error, VersionInfo};


### PR DESCRIPTION
We replace substrate’s default logger with our own. The goal is to make the logs easily readable for development purposes.

* We only show the local time and omit the date.
* We log to stdout instead of stderr since there is no other stdout output.
* We format the non-message part of the logs in grey to simplify reading.