### PR TITLE
Replace substrate command line parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ To build the node from source see [`DEVELOPING.md`][dev-manual].
 Running the node
 ----------------
 
-The node can be run in development mode or with a specified chain. Currently,
-only the `devnet` chain is available.
+To run a node you need to specify the chain
+~~~
+radicle-registry-node --chain devnet
+~~~
+
+See below for more information on the different chains.
 
 For more information use the `--help` flag.
 
@@ -65,19 +69,10 @@ the [`RUST_LOG` environment variable][rust-log-docs].
 
 [rust-log-docs]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
 
-### Dev Mode
+### Dev
 
-In development mode the node runs an isolated network with only the node as a block miner
-
-~~~
-radicle-registry-node --dev
-~~~
-
-To reset the chain state and start fresh run
-
-~~~
-radicle-registry-node purge-chain --dev
-~~~
+The `dev` chain is intended for local development. The node runs an isolated
+network with a dummy proof-of-work.
 
 ### Devnet
 
@@ -90,7 +85,7 @@ radicle-registry-node --chain devnet
 
 We are frequently resetting the devnet blockchain. If you local node is not
 syncing blocks download the most recent version and run `radicle-registry-node
-purge-chain --chain devnet`.
+--chain devnet purge-chain`.
 
 
 Using the Client

--- a/ci/run
+++ b/ci/run
@@ -57,8 +57,8 @@ cargo build --workspace --all-targets --release
 echo "--- cargo test"
 echo "Starting radicle-registry-node"
 RUST_LOG=error ./target/release/radicle-registry-node \
-  --dev \
-  --base-path /tmp/radicle-registry \
+  --chain dev \
+  --data-path /tmp/radicle-registry \
   &
 registry_node_pid=$!
 # We build tests in release mode so that we can reuse the artifacts

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Defines the [ChainSpec]s for various chains we want to run.
+//! Provides [Chain] and [ChainSpec]s for various chains we want to run.
 //!
 //! Available chain specs
 //! * [dev] for runnning a single node locally and develop against it.
@@ -28,25 +28,23 @@ use std::convert::TryFrom;
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::ChainSpec<GenesisConfig>;
 
-pub fn load_spec(id: &str) -> Result<Option<ChainSpec>, String> {
-    match from_id(id) {
-        Some(spec) => Ok(Some(spec)),
-        _ => Err(format!(
-            "Unknown chain spec \"{}\". You must run the node with --dev",
-            id
-        )),
-    }
+/// Possible chains.
+///
+/// Use [Chain::spec] to get the corresponding [ChainSpec].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Chain {
+    Dev,
+    DevnetLocal,
+    Devnet,
 }
 
-pub fn from_id(id: &str) -> Option<ChainSpec> {
-    if id == "dev" {
-        Some(dev())
-    } else if id == "devnet" {
-        Some(devnet())
-    } else if id == "local-devnet" {
-        Some(local_devnet())
-    } else {
-        None
+impl Chain {
+    pub fn spec(&self) -> ChainSpec {
+        match self {
+            Chain::Dev => dev(),
+            Chain::DevnetLocal => local_devnet(),
+            Chain::Devnet => devnet(),
+        }
     }
 }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -13,14 +13,132 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+//! Provides [Arguments] struct that represents the command line arguments.
 use sc_cli::{RunCmd, Subcommand};
-use structopt::StructOpt;
+use structopt::{clap, StructOpt};
 
+use crate::chain_spec::Chain;
+
+/// Command line arguments.
+///
+/// Implements [StructOpt] for parsing.
 #[derive(Debug, StructOpt)]
-pub struct Cli {
+pub struct Arguments {
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 
-    #[structopt(flatten)]
-    pub run: RunCmd,
+    /// Chain to connect to.
+    #[structopt(
+        long,
+        default_value = "dev",
+        value_name = "CHAIN",
+        parse(try_from_str = parse_chain),
+        possible_values = &["dev", "local-devnet", "devnet"]
+    )]
+    pub chain: Chain,
+
+    /// Human-readable name for this node to use for telemetry'
+    #[structopt(long, value_name = "NAME")]
+    name: Option<String>,
+
+    /// Bind the RPC HTTP and WebSocket APIs to `0.0.0.0` instead of the local interface.
+    #[structopt(long)]
+    unsafe_rpc_external: bool,
+
+    /// List of nodes to connect to on start'
+    #[structopt(long, short, value_name = "ADDR")]
+    bootnodes: Vec<String>,
+
+    /// Where to store data
+    #[structopt(long, short, value_name = "PATH")]
+    data_path: Option<std::path::PathBuf>,
+
+    /// The URL of the telemetry server to connect to.
+    ///
+    /// This flag can be passed multiple times as a mean to specify multiple
+    /// telemetry endpoints.
+    #[structopt(long, short, value_name = "URL")]
+    telemetry_endpoints: Vec<String>,
+
+    /// The secret key to use for libp2p networking provided as a hex-encoded Ed25519 32 bytes
+    /// secret key.
+    ///
+    /// The value of this option takes precedence over `--node-key-file`.
+    ///
+    /// WARNING: Secrets provided as command-line arguments are easily exposed.
+    /// Use of this option should be limited to development and testing. To use
+    /// an externally managed secret key, use `--node-key-file` instead.
+    #[structopt(long, value_name = "HEX_KEY")]
+    node_key: Option<String>,
+
+    /// The file from which to read the node's secret key to use for libp2p networking.
+    ///
+    /// The file must contain an unencoded 32 bytes Ed25519 secret key.
+    ///
+    /// If the file does not exist, it is created with a newly generated secret key.
+    #[structopt(long, value_name = "FILE")]
+    node_key_file: Option<std::path::PathBuf>,
+}
+
+impl Arguments {
+    /// Similar to [StructOpt::from_args] with additional information filled in by `version_info`.
+    pub fn from_args(version_info: &sc_cli::VersionInfo) -> Self {
+        let app = Arguments::clap()
+            .max_term_width(80)
+            .name(version_info.executable_name)
+            .author(version_info.author)
+            .about(version_info.description)
+            // We need to manually reset the `long_about` so that `structopt` does not take the
+            // code documentation of `Subcommand` for it.
+            .long_about("")
+            .settings(&[clap::AppSettings::UnifiedHelpMessage]);
+        Arguments::from_clap(&app.get_matches())
+    }
+
+    pub fn run_cmd(self) -> RunCmd {
+        // This does not panic if there are no required arguments which we statically know.
+        let mut run_cmd = RunCmd::from_iter_safe(vec![] as Vec<String>).unwrap();
+
+        let Arguments {
+            bootnodes,
+            data_path,
+            name,
+            node_key,
+            node_key_file,
+            telemetry_endpoints,
+            unsafe_rpc_external,
+            ..
+        } = self;
+
+        run_cmd.network_config.bootnodes = bootnodes;
+        run_cmd.network_config.node_key_params.node_key = node_key;
+        run_cmd.network_config.node_key_params.node_key_file = node_key_file;
+        run_cmd.shared_params.base_path = data_path;
+
+        // Add verbosity 0 to all endpoints.
+        let telemetry_endpoints = telemetry_endpoints
+            .into_iter()
+            .map(|url| (url, 0))
+            .collect();
+
+        RunCmd {
+            name,
+            telemetry_endpoints,
+            unsafe_rpc_external,
+            ..run_cmd
+        }
+    }
+}
+
+// NOTE Update `possible_values` in the structopt attribute if something is added here.
+fn parse_chain(name: &str) -> Result<Chain, String> {
+    if name == "dev" {
+        Ok(Chain::Dev)
+    } else if name == "local-devnet" {
+        Ok(Chain::DevnetLocal)
+    } else if name == "devnet" {
+        Ok(Chain::Devnet)
+    } else {
+        Err(format!("Invalid chain {}", name))
+    }
 }

--- a/scripts/build-dev-node
+++ b/scripts/build-dev-node
@@ -6,5 +6,5 @@
 set -euo pipefail
 
 BUILD_DUMMY_WASM_BINARY=0 cargo build -p radicle-registry-node --release
-(set +o pipefail;  yes | ./target/release/radicle-registry-node purge-chain --dev)
+(set +o pipefail;  yes | ./target/release/radicle-registry-node --chain dev purge-chain)
 echo "Node binary ./target/release/radicle-registry-node was successfully built"

--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
+export RUST_LOG="${RUST_LOG:-info},substrate_consensus_slots=error,substrate=error"
 radicle_registry_node=./target/release/radicle-registry-node
-exec $radicle_registry_node "$@" --dev
+exec $radicle_registry_node "$@" --chain dev


### PR DESCRIPTION
We stop parsing all the substrate command line options from `sc_cli::RunCmd`. The goal is to not expose irrelevant or confusing options to the user. This also sets the stage for adding our own command line options (e.g. for block rewards).

Requires an update of the devnet run script.