### PR TITLE
Use “info” as default log level

### DIFF
--- a/node/src/logger.rs
+++ b/node/src/logger.rs
@@ -19,7 +19,8 @@ use std::io::Write as _;
 
 /// Initializes [env_logger] using the `RUST_LOG` environment variables and our custom formatter.
 pub fn init() {
-    env_logger::Builder::from_default_env()
+    let env = env_logger::Env::new().default_filter_or("info");
+    env_logger::Builder::from_env(env)
         .format(format_record)
         .target(env_logger::Target::Stdout)
         .init();

--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -2,6 +2,5 @@
 
 set -euo pipefail
 
-export RUST_LOG="${RUST_LOG:-info},substrate_consensus_slots=error,substrate=error"
 radicle_registry_node=./target/release/radicle-registry-node
 exec $radicle_registry_node "$@" --dev


### PR DESCRIPTION
Use “info” as default log level across the board. Before, the log level was “warn” which is not helpful.