### PR TITLE
Also expose WebSocket RPC with CLI flag

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -125,6 +125,7 @@ impl Arguments {
             name,
             telemetry_endpoints,
             unsafe_rpc_external,
+            unsafe_ws_external: unsafe_rpc_external,
             ..run_cmd
         }
     }


### PR DESCRIPTION
The `--unsafe-rpc-external` flag now also exposes the WebSocket RPC API publicly. This is in line with the documentation for the CLI flag.

The idea is that we want the HTTP and WebSocket APIs to behave the same.