### PR TITLE
Remove executor boilerplate in client examples

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/radicle-dev/radicle-registry"
 radicle-registry-core = { version = "0.0.0", path = "../core" }
 radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
 
-async-std = { version = "1.4", features = ["attributes"] }
 async-trait = "0.1"
 derive_more = "0.15"
 env_logger = "0.7"
@@ -63,6 +62,7 @@ git = "https://github.com/paritytech/substrate"
 rev = "09abd3b436ea568a47ec4fc47f933728d8cf466b"
 
 [dev-dependencies]
+async-std = { version = "1.4", features = ["attributes"] }
 rand = "0.7.2"
 radicle-registry-test-utils = { path = "../test-utils"}
 serial_test = "0.3.2"

--- a/client/examples/getting_started.rs
+++ b/client/examples/getting_started.rs
@@ -4,27 +4,13 @@
 //!
 //! To run this example you need a running dev node. You can start it with
 //! `./scripts/run-dev-node`.
-use futures::compat::Compat;
-use futures::future::FutureExt;
 
 use radicle_registry_client::*;
 
-// Wrapper to run the async function `go`.
-fn main() {
+#[async_std::main]
+async fn main() -> Result<(), Error> {
     env_logger::init();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    let result = runtime.block_on(Compat::new(go().boxed()));
-    match result {
-        Ok(()) => (),
-        Err(err) => {
-            println!("ERROR: {:?}", err);
-            std::process::exit(1)
-        }
-    }
-}
 
-// We call [Future01CompatExt::compat] on all futures because the client only uses futures v0.1.
-async fn go() -> Result<(), Error> {
     // Create a key pair to author transactions from some seed data. This account is initialized
     // with funds on the local development chain.
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
@@ -37,7 +23,7 @@ async fn go() -> Result<(), Error> {
     // Create and connect to a client on local host
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     println!("Connecting to node on {}", node_host);
-    let client = Client::create(node_host).await?;
+    let client = Client::create_with_executor(node_host).await?;
 
     // Show balances of Alice’s and Bob’s accounts
     let balance_alice = client.free_balance(&alice.public()).await?;

--- a/client/examples/project_registration.rs
+++ b/client/examples/project_registration.rs
@@ -1,23 +1,15 @@
 //! Register a project on the ledger
-use futures::compat::{Compat, Future01CompatExt};
-use futures::future::FutureExt;
 use std::convert::TryFrom;
 
 use radicle_registry_client::*;
 
 #[async_std::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
     env_logger::init();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime.block_on(Compat::new(go().boxed())).unwrap();
-    runtime.shutdown_now().compat().await.unwrap();
-}
-
-async fn go() -> Result<(), Error> {
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
 
     let node_host = url::Host::parse("127.0.0.1").unwrap();
-    let client = Client::create(node_host).await?;
+    let client = Client::create_with_executor(node_host).await?;
 
     let project_name = ProjectName::try_from("radicle-registry").unwrap();
     let org_id = OrgId::try_from("monadic").unwrap();

--- a/client/examples/transaction_signing.rs
+++ b/client/examples/transaction_signing.rs
@@ -1,23 +1,13 @@
 //! Offline signing and creation of a `Transfer` transaction.
-use futures::compat::Compat;
-use futures::future::FutureExt;
 
-use radicle_registry_client::{
-    ed25519, message::Transfer, Client, ClientT as _, CryptoPair as _, Error, Transaction,
-    TransactionExtra,
-};
+use radicle_registry_client::*;
 
-fn main() {
-    env_logger::init();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime.block_on(Compat::new(go().boxed())).unwrap();
-}
-
-async fn go() -> Result<(), Error> {
+#[async_std::main]
+async fn main() -> Result<(), Error> {
     let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
     let bob = ed25519::Pair::from_string("//Bob", None).unwrap();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
-    let client = Client::create(node_host).await?;
+    let client = Client::create_with_executor(node_host).await?;
 
     // Construct `TransactionExtra` data that is required to validate a transaction.
     let account_nonce = client.account_nonce(&alice.public()).await?;
@@ -30,7 +20,7 @@ async fn go() -> Result<(), Error> {
     // Construct the transaction
     let transfer_tx = Transaction::new_signed(
         &alice,
-        Transfer {
+        message::Transfer {
             recipient: bob.public(),
             balance: 1000,
         },


### PR DESCRIPTION
In the client examples we remove the confusing `tokio` runtime boilerplate. Instead we just use the client with the included executor.