### PR TITLE
Fix failing low transfers

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -169,7 +169,10 @@ impl pallet_timestamp::Trait for Runtime {
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u128 = 500;
+    /// The minimum amount required to keep an account open.
+    /// Transfers leaving the recipient with less than this
+    /// value fail.
+    pub const ExistentialDeposit: u128 = 1;
     pub const TransferFee: u128 = 0;
     pub const CreationFee: u128 = 0;
     pub const TransactionBaseFee: u128 = 0;

--- a/runtime/tests/transfer.rs
+++ b/runtime/tests/transfer.rs
@@ -25,6 +25,33 @@ async fn transfer_fail() {
     assert!(tx_applied.result.is_err());
 }
 
+// Test that we can transfer any amount within a reasonable range.
+// Affected by the [crate::ExistentialDeposit] parameter.
+#[async_std::test]
+async fn transfer_any_amount() {
+    let client = Client::new_emulator();
+    let donator = key_pair_from_string("Alice");
+    let receipient = key_pair_from_string("Bob").public();
+
+    for amount in (1..10000).step_by(500) {
+        let tx_applied = submit_ok(
+            &client,
+            &donator,
+            message::Transfer {
+                recipient: receipient,
+                balance: amount,
+            },
+        )
+        .await;
+        assert_eq!(
+            tx_applied.result,
+            Ok(()),
+            "Failed to transfer {} RAD",
+            amount
+        );
+    }
+}
+
 /// Test that we can transfer money to an org account and that the
 /// org owner can transfer money from an org to another account.
 #[async_std::test]


### PR DESCRIPTION
Fixes #244 

Change the 'ExistencialDeposit' parameter passed when defining the
runtime. Test that we can transfer any amount within a reasonable range
to cover ourselves from re-introducing this bug again.


### Discussion

It's a shame that `ExistencialDeposit` is used both as the minimum amount required to keep an account open and as a minimum transfer amount. I set it from 500 to 1 but maybe something in between would be better to keep the accounts cleaner. 