### PR TITLE
Implement block rewards

### DIFF
--- a/node/src/inherent_data.rs
+++ b/node/src/inherent_data.rs
@@ -1,0 +1,31 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Provides [InherentDataProviders] for the registry [InherentData].
+use radicle_registry_runtime::registry::InherentData;
+use radicle_registry_runtime::AccountId;
+use sp_inherents::InherentDataProviders;
+
+/// Return [InherentDataProviders] that provides [InherentData] for registry blocks required by
+/// full nodes.
+pub fn new_full_providers() -> InherentDataProviders {
+    let providers = InherentDataProviders::new();
+    let data = InherentData {
+        block_author: AccountId::from_raw([0u8; 32]),
+    };
+    // Can only fail if a provider with the same name is already registered.
+    providers.register_provider(data).unwrap();
+    providers
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -21,6 +21,7 @@
 mod chain_spec;
 mod cli;
 mod command;
+mod inherent_data;
 mod logger;
 mod pow;
 mod service;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -39,7 +39,7 @@ native_executor_instance!(
 macro_rules! new_full_start {
     ($config:expr) => {{
         let mut import_setup = None;
-        let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+        let inherent_data_providers = crate::inherent_data::new_full_providers();
 
         let builder = sc_service::ServiceBuilder::new_full::<Block, RuntimeApi, Executor>($config)?
             .with_select_chain(|_config, backend| {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -209,7 +209,7 @@ construct_runtime!(
                 RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
                 Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
                 Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
-                Registry: registry::{Module, Call, Storage, Event},
+                Registry: registry::{Module, Call, Storage, Event, Inherent},
         }
 );
 

--- a/runtime/src/registry/inherents.rs
+++ b/runtime/src/registry/inherents.rs
@@ -1,0 +1,118 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Defines [InherentData] for the registry module and implement [ProvideInherent].
+
+use frame_support::traits::GetCallName as _;
+use parity_scale_codec::{Decode, Encode};
+use sp_inherents::{InherentIdentifier, IsFatalError, ProvideInherent};
+use sp_runtime::RuntimeString;
+
+use radicle_registry_core::AccountId;
+
+use super::{Call, Module, Trait};
+use crate::Hash;
+
+const INHERENT_IDENTIFIER: InherentIdentifier = *b"registry";
+
+/// Structured inherent data for the registry
+#[derive(Encode, Decode)]
+pub struct InherentData {
+    pub block_author: AccountId,
+}
+
+#[cfg(feature = "std")]
+impl sp_inherents::ProvideInherentData for InherentData {
+    fn inherent_identifier(&self) -> &'static InherentIdentifier {
+        &INHERENT_IDENTIFIER
+    }
+
+    fn provide_inherent_data(
+        &self,
+        inherent_data: &mut sp_inherents::InherentData,
+    ) -> Result<(), sp_inherents::Error> {
+        inherent_data.put_data(INHERENT_IDENTIFIER, &self)
+    }
+
+    fn error_to_string(&self, mut error: &[u8]) -> Option<String> {
+        let inherent_error = CheckInherentError::decode(&mut error).ok()?;
+        Some(format!("{}", inherent_error))
+    }
+}
+
+/// Error returned for the [ProvideInherent] implementation of [Module].
+#[derive(Encode)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub enum CheckInherentError {
+    /// The call is forbidden for an inherent. `name` is the name of the call as returned by
+    /// [frame_support::traits::GetCallName::get_call_name].
+    ForbiddenCall { name: RuntimeString },
+}
+
+impl IsFatalError for CheckInherentError {
+    fn is_fatal_error(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for CheckInherentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match self {
+            CheckInherentError::ForbiddenCall { name } => {
+                write!(f, "Call {} is forbidden for inherents", name)
+            }
+        }
+    }
+}
+
+impl<T: Trait> ProvideInherent for Module<T>
+where
+    T: frame_system::Trait<
+        AccountId = AccountId,
+        Origin = crate::Origin,
+        Hash = Hash,
+        OnNewAccount = (),
+    >,
+    <T as frame_system::Trait>::Event: From<frame_system::RawEvent<AccountId>>,
+    <T as frame_system::Trait>::OnKilledAccount:
+        frame_support::traits::OnKilledAccount<T::AccountId>,
+    <T as frame_system::Trait>::MigrateAccount: frame_support::traits::MigrateAccount<AccountId>,
+{
+    type Call = Call<T>;
+    type Error = CheckInherentError;
+    const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+    fn create_inherent(raw_data: &sp_inherents::InherentData) -> Option<Self::Call> {
+        let data = raw_data
+            .get_data::<InherentData>(&INHERENT_IDENTIFIER)
+            .expect("Failed to decode registry InherentData")
+            .expect("InherentData for registry is missing");
+
+        Some(Call::set_block_author(data.block_author))
+    }
+
+    fn check_inherent(
+        call: &Self::Call,
+        _data: &sp_inherents::InherentData,
+    ) -> Result<(), Self::Error> {
+        match call {
+            Call::set_block_author(_) => Ok(()),
+            _ => Err(CheckInherentError::ForbiddenCall {
+                name: RuntimeString::from(call.get_call_name()),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
We add a block author inherent to the runtime and credit the author with block rewards and transaction fees.

We don’t implement setting the block author from the CLI yet.

The code enforces some invariants with `panic!`s and `assert!`s. This follows common substrate practice. (See [`pallet_timestamp`][1] for example.)

[1]: https://github.com/paritytech/substrate/blob/1ea615c0a422fdbc7ecdbc7357bdf7f5bbdc421b/frame/timestamp/src/lib.rs#L149