### PR TITLE
Add Grafana and Prometheus to local devnet

### DIFF
--- a/local-devnet/README.md
+++ b/local-devnet/README.md
@@ -5,11 +5,12 @@ This directory provides tools to run and experiment with a local devnet.
 
 To run the devnet you need to build the registry node with
 ```bash
-cargo build --release -p radicle-registry-node
+./scripts/build-dev-node
 ```
 Then you can start the network with `docker-compose up`
 
-### Overview
+Overview
+--------
 
 * Devnet consists of three miner nodes.
 * Chain data of nodes is persisted in Docker volumes.
@@ -17,3 +18,11 @@ Then you can start the network with `docker-compose up`
 * See `local_devnet()` for chain spec in `../node/src/chain_spec.rs`.
 * You need to build the node using a target that is compatible with Ubuntu 19.10
   (Eoan).
+
+Monitoring
+----------
+
+The local DevNet provides Grafana dashboards for the nodes at
+`http://localhost:9004`. The login credentials are `admin:admin`.
+
+Monitoring can be configured with `./prometheus.yaml`, `./grafana-datasources.yaml`, `./grafana-dashboards.yaml`, and `./grafana-dashboards`.

--- a/local-devnet/docker-compose.yaml
+++ b/local-devnet/docker-compose.yaml
@@ -4,7 +4,7 @@ version: "3.7"
 x-node: &node
   image: ubuntu:eoan-20191101
   volumes:
-  - ../target/debug/radicle-registry-node:/usr/local/bin/radicle-registry-node:ro
+  - ../target/release/radicle-registry-node:/usr/local/bin/radicle-registry-node:ro
   - ./start-node.sh:/usr/local/bin/start-node.sh:ro
   # Used by the --base-path option
   - /data

--- a/local-devnet/docker-compose.yaml
+++ b/local-devnet/docker-compose.yaml
@@ -4,7 +4,7 @@ version: "3.7"
 x-node: &node
   image: ubuntu:eoan-20191101
   volumes:
-  - ../target/release/radicle-registry-node:/usr/local/bin/radicle-registry-node:ro
+  - ../target/debug/radicle-registry-node:/usr/local/bin/radicle-registry-node:ro
   - ./start-node.sh:/usr/local/bin/start-node.sh:ro
   # Used by the --base-path option
   - /data
@@ -26,3 +26,25 @@ services:
     <<: *node
     environment:
       NODE_NAME: charlie
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+    - "9090:9090"
+    volumes:
+    - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana
+    ports:
+    - "9004:3000"
+    volumes:
+    - grafana-data:/var/lib/grafana
+    - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    - ./grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+    - ./grafana-dashboards:/var/lib/grafana/dashboards
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/local-devnet/grafana-dashboards.yaml
+++ b/local-devnet/grafana-dashboards.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+- name: dashboards
+  folder: ''
+  type: file
+  editable: true
+  allowUiUpdates: true
+  options:
+    path: /var/lib/grafana/dashboards

--- a/local-devnet/grafana-dashboards/network.json
+++ b/local-devnet/grafana-dashboards/network.json
@@ -1,0 +1,232 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(substrate_block_height_number{status=\"sync_target\"}[10m]) * 60",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(substrate_block_height_number{status=\"sync_target\"}[10m]) * 60)",
+          "intervalFactor": 1,
+          "legendFormat": "average",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block production rate over 10 minutes by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "blocks/minute",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "substrate_block_height_number{status=\"best\"}",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block height by node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "block height",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 21,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Network",
+  "uid": "nQSOAF9Zz",
+  "version": 5
+}

--- a/local-devnet/grafana-datasources.yaml
+++ b/local-devnet/grafana-datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+- name: Prometheus
+  type: prometheus
+  isDefault: true
+  access: proxy
+  url: "http://prometheus:9090"
+  jsonData:
+    timeInterval: 5s

--- a/local-devnet/prometheus.yaml
+++ b/local-devnet/prometheus.yaml
@@ -1,0 +1,12 @@
+scrape_configs:
+- job_name: registry-nodes
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - alice:9615
+    - bob:9615
+    - charlie:9615
+  relabel_configs:
+  - source_labels: ["__address__"]
+    regex: "([^:]*):.*"
+    target_label: "instance"

--- a/local-devnet/start-node.sh
+++ b/local-devnet/start-node.sh
@@ -15,5 +15,6 @@ exec /usr/local/bin/radicle-registry-node \
   --name "$NODE_NAME" \
   --chain local-devnet \
   --unsafe-rpc-external \
+  --prometheus-external \
   --bootnodes /dns4/alice/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR \
   "${extra_args[@]}"


### PR DESCRIPTION
To allow us to play with metrics for the local devnet we add Grafana and Prometheus to our local devnet. We also provision a basic dashboard with some network metrics.