### PR TITLE
node: Update version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
  "time 0.2.9",
  "tokio 0.2.13",
  "trie-root 0.15.2",
+ "vergen",
 ]
 
 [[package]]
@@ -6386,6 +6387,16 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "vergen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
+dependencies = [
+ "bitflags",
+ "chrono",
+]
 
 [[package]]
 name = "version_check"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -103,3 +103,6 @@ rev = "f7bd10a548201cb68491f72be73115279d97f160"
 [dependencies.sp-api]
 git = "https://github.com/paritytech/substrate"
 rev = "f7bd10a548201cb68491f72be73115279d97f160"
+
+[build-dependencies]
+vergen = "3"

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,0 +1,5 @@
+use vergen::{generate_cargo_keys, ConstantsFlags};
+
+fn main() {
+    generate_cargo_keys(ConstantsFlags::SHA_SHORT).unwrap();
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -28,14 +28,12 @@ mod service;
 fn main() {
     let version = sc_cli::VersionInfo {
         name: "Radicle Registry Node",
-        commit: "<none>",
-        // commit: env!("VERGEN_SHA_SHORT"),
-        // version: env!("CARGO_PKG_VERSION"),
-        version: "unstable",
+        commit: env!("VERGEN_SHA_SHORT"),
+        version: "ff.0",
         executable_name: "radicle-registry",
         author: "Monadic GmbH",
         description: "Radicle Registry Node",
-        support_url: "support.anonymous.an",
+        support_url: "http://github.com/radicle-dev/radicle-registry/issues",
         copyright_start_year: 2019,
     };
 


### PR DESCRIPTION
We ensure that the node includes the commit hash. This is helpful for identifying the node build with monitoring and through logs.

We also update the support URL and use `ff` (for Friends&Family-Net) for the version.