### PR TITLE
Node only mines if block author is provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Upcoming
 * The error type in `get_dispatch_result` has changed from
   `Option<&'static str>` to `sp_runtime::DispatchError`.
 * The `Client` and `ClientT` methods are now `async`.
+* The `--block-author` option was replaced with the `--mine` option. A node only
+  mines if the option is given.
 
 ### Addition
 * The client emulator now authors blocks when a transaction is submitted.

--- a/ci/run
+++ b/ci/run
@@ -63,6 +63,7 @@ echo "--- cargo test"
 echo "Starting radicle-registry-node"
 RUST_LOG=error ./target/release/radicle-registry-node \
   --chain dev \
+  --mine 5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq \
   --data-path /tmp/radicle-registry \
   &
 registry_node_pid=$!

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -61,8 +61,8 @@ impl Emulator {
         let mut test_ext = sp_io::TestExternalities::new(genesis_config.build_storage().unwrap());
         let genesis_hash = init_runtime(&mut test_ext);
 
-        let registry_inherent_data = registry::InherentData {
-            block_author: AccountId::from_raw([0u8; 32]),
+        let registry_inherent_data = registry::AuthoringInherentData {
+            block_author: BLOCK_AUTHOR,
         };
 
         let inherent_data_providers = sp_inherents::InherentDataProviders::new();

--- a/local-devnet/start-node.sh
+++ b/local-devnet/start-node.sh
@@ -10,10 +10,14 @@ if [[ "$NODE_NAME" = "alice" ]]; then
   )
 fi
 
+# Adress for the seed string //Mine
+block_author=5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq
+
 exec /usr/local/bin/radicle-registry-node \
   --data-path /data \
   --name "$NODE_NAME" \
   --chain local-devnet \
+  --mine "$block_author" \
   --unsafe-rpc-external \
   --prometheus-external \
   --bootnodes /dns4/alice/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR \

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -80,12 +80,11 @@ pub struct Arguments {
     #[structopt(long, value_name = "FILE")]
     node_key_file: Option<std::path::PathBuf>,
 
-    /// Account to credit block rewards and transaction fees for mined blocks.
+    /// Enable mining and credit rewards to the given account.
     ///
-    /// If not provided the zero account is used as the block author.
-    /// Account address must be given in SS58 format.
+    /// The account address must be given in SS58 format.
     #[structopt(long, value_name = "SS58_ADDRESS", parse(try_from_str = parse_ss58_account_id))]
-    block_author: Option<AccountId>,
+    pub mine: Option<AccountId>,
 
     /// Bind the prometheus metrics endpoint to 0.0.0.0
     #[structopt(long)]
@@ -142,11 +141,6 @@ impl Arguments {
             prometheus_external,
             ..run_cmd
         }
-    }
-
-    pub fn block_author(&self) -> AccountId {
-        let zero_account = AccountId::from_raw([0; 32]);
-        self.block_author.unwrap_or(zero_account)
     }
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -28,8 +28,8 @@ pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
     let chain_spec = args.chain.spec();
     let spec_factory = |_: &str| Ok(Box::new(chain_spec) as Box<_>);
 
-    let block_author = args.block_author();
-    let new_full_service = move |config| service::new_full(config, block_author);
+    let opt_block_author = args.mine;
+    let new_full_service = move |config| service::new_full(config, opt_block_author);
 
     match args.subcommand {
         Some(subcommand) => {

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -34,7 +34,7 @@ use crate::{AccountId, Hash, Hashing};
 
 mod inherents;
 
-pub use inherents::InherentData;
+pub use inherents::AuthoringInherentData;
 
 pub trait Trait
 where

--- a/runtime/src/registry/inherents.rs
+++ b/runtime/src/registry/inherents.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Defines [InherentData] for the registry module and implement [ProvideInherent].
+//! Defines [AuthoringInherentData] for the registry module and implement [ProvideInherent].
 
 use frame_support::traits::GetCallName as _;
 use parity_scale_codec::{Decode, Encode};
@@ -27,14 +27,14 @@ use crate::Hash;
 
 const INHERENT_IDENTIFIER: InherentIdentifier = *b"registry";
 
-/// Structured inherent data for the registry
+/// Structured inherent data for authoring blocks
 #[derive(Encode, Decode)]
-pub struct InherentData {
+pub struct AuthoringInherentData {
     pub block_author: AccountId,
 }
 
 #[cfg(feature = "std")]
-impl sp_inherents::ProvideInherentData for InherentData {
+impl sp_inherents::ProvideInherentData for AuthoringInherentData {
     fn inherent_identifier(&self) -> &'static InherentIdentifier {
         &INHERENT_IDENTIFIER
     }
@@ -96,9 +96,9 @@ where
 
     fn create_inherent(raw_data: &sp_inherents::InherentData) -> Option<Self::Call> {
         let data = raw_data
-            .get_data::<InherentData>(&INHERENT_IDENTIFIER)
-            .expect("Failed to decode registry InherentData")
-            .expect("InherentData for registry is missing");
+            .get_data::<AuthoringInherentData>(&INHERENT_IDENTIFIER)
+            .expect("Failed to decode registry AuhoringInherentData")
+            .expect("AuhoringInherentData for registry is missing");
 
         Some(Call::set_block_author(data.block_author))
     }

--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -3,5 +3,7 @@
 set -euo pipefail
 
 export RUST_LOG="${RUST_LOG:-info},substrate_consensus_slots=error,substrate=error"
+# Adress for the seed string //Mine
+block_author=5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq
 radicle_registry_node=./target/release/radicle-registry-node
-exec $radicle_registry_node "$@" --chain dev
+exec $radicle_registry_node "$@" --chain dev --mine "$block_author"


### PR DESCRIPTION
Fixes #288.

We replace the `--block-author` option with the `--mine` option. A block mines only if `--mine` is specified. The option requires the block author account.

- [ ] Update devnet scripts