### PR TITLE
Disable CORS check when --unsafe-rpc-external is enabled

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -44,7 +44,7 @@ pub struct Arguments {
 
     /// Bind the RPC HTTP and WebSocket APIs to `0.0.0.0` instead of the local interface.
     #[structopt(long)]
-    unsafe_rpc_external: bool,
+    pub unsafe_rpc_external: bool,
 
     /// List of nodes to connect to on start'
     #[structopt(long, short, value_name = "ADDR")]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -38,9 +38,14 @@ pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
             subcommand.run(config, service::new_for_command)
         }
         None => {
+            let unsafe_rpc_external = args.unsafe_rpc_external;
             let run_cmd = args.run_cmd();
             run_cmd.init(&version)?;
             run_cmd.update_config(&mut config, spec_factory, &version)?;
+            if unsafe_rpc_external {
+                // Allow all hosts to connect
+                config.rpc_cors = None;
+            }
             run_cmd.run(config, service::new_light, new_full_service, &version)
         }
     }


### PR DESCRIPTION
We disable the RPC API server side check for connections. Fixes #301.