### PR TITLE
cli: Add account generate and list commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.1",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +826,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3518,10 +3551,13 @@ dependencies = [
  "async-std",
  "async-trait",
  "derive_more 0.99.3",
+ "directories",
  "futures 0.3.4",
  "hex",
  "pretty_env_logger",
  "radicle-registry-client",
+ "serde",
+ "serde_json",
  "sp-core",
  "structopt",
  "thiserror",
@@ -3889,6 +3925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,6 +4004,18 @@ checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64 0.11.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,7 @@ dependencies = [
  "radicle-registry-client",
  "sp-core",
  "structopt",
+ "thiserror",
  "url 1.7.2",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,12 +15,16 @@ radicle-registry-client = { version = "0.0.0", path = "../client" }
 async-std = { version = "1.4", features = ["attributes"] }
 async-trait = "0.1"
 derive_more = "0.99"
+directories = "2.0.2"
 futures = "0.3"
 hex = "0.4.0"
 pretty_env_logger = "0.3.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 structopt = "0.3"
 thiserror = "1.0"
 url = "1.7"
+
 
 [dependencies.sp-core]
 git = "https://github.com/paritytech/substrate"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 hex = "0.4.0"
 pretty_env_logger = "0.3.1"
 structopt = "0.3"
+thiserror = "1.0"
 url = "1.7"
 
 [dependencies.sp-core]

--- a/cli/src/account_storage.rs
+++ b/cli/src/account_storage.rs
@@ -1,0 +1,112 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Manages accounts stored in the filesystem,
+//! providing ways to store and retrieve them.
+
+use directories::BaseDirs;
+use sp_core::serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use thiserror::Error as ThisError;
+
+use std::io::Error as IOError;
+use std::path::PathBuf;
+
+/// The data that is stored in the filesystem relative
+/// to an account. The account name is used as the key
+/// to this value, therefore not included here.
+#[derive(Serialize, Deserialize)]
+pub struct AccountData {
+    pub seed: Seed,
+}
+
+/// The seed from which an account's key pair
+/// can be determiniscally generated.
+type Seed = [u8; 32];
+
+#[derive(Debug, ThisError)]
+pub enum Error {
+    /// An Account with the given name already exists
+    #[error("An account with the given name already exists")]
+    AlreadyExists(),
+
+    /// An IOError occurred
+    #[error("An IO error occured: {0}")]
+    IOError(IOError),
+
+    /// A serde json Error occurred
+    #[error("A serde json error occured: {0}")]
+    JsonError(serde_json::Error),
+}
+
+/// Add an account to the storage.
+///
+/// Fails if an account with the given `name` already exists.
+/// It can also fail from IO and Serde Json errors.
+pub fn add(name: String, data: AccountData) -> Result<(), Error> {
+    let mut accounts = list()?;
+    if accounts.contains_key(&name) {
+        return Err(Error::AlreadyExists());
+    }
+
+    accounts.insert(name, data);
+    update(accounts)
+}
+
+/// List all the stored accounts
+///
+/// It can fail from IO and Serde Json errors.
+pub fn list() -> Result<HashMap<String, AccountData>, Error> {
+    let path_buf = get_or_create_path()?;
+    let file = File::open(path_buf.as_path()).map_err(Error::IOError)?;
+    let accounts: HashMap<String, AccountData> =
+        serde_json::from_reader(&file).map_err(Error::JsonError)?;
+    Ok(accounts)
+}
+
+fn update(accounts: HashMap<String, AccountData>) -> Result<(), Error> {
+    let path_buf = get_or_create_path()?;
+    let new_content = serde_json::to_string(&accounts).map_err(Error::JsonError)?;
+    std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(Error::IOError)
+}
+
+const FILE: &str = "accounts.json";
+
+// Get the path to the accounts file on disk.
+//
+// If the file does not yet exist, create it and initialize
+// it with an empty object so that it can be deserialized
+// as an empty HashMap<String, AccountData>.
+fn get_or_create_path() -> Result<PathBuf, Error> {
+    let dir = dir()?;
+    let path_buf = dir.join(FILE);
+    let path = path_buf.as_path();
+
+    if !path.exists() {
+        std::fs::write(path, b"{}").map_err(Error::IOError)?
+    }
+
+    Ok(path_buf)
+}
+
+fn dir() -> Result<PathBuf, Error> {
+    let dir = BaseDirs::new()
+        .unwrap()
+        .data_dir()
+        .join("radicle-registry-cli");
+    std::fs::create_dir_all(&dir).map_err(Error::IOError)?;
+    Ok(dir)
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,6 +18,8 @@
 use radicle_registry_client::*;
 use structopt::StructOpt;
 
+pub mod account_storage;
+
 mod command;
 use command::{account, org, other, project, user};
 
@@ -147,6 +149,7 @@ pub enum CommandError {
         project_name: ProjectName,
         org_id: OrgId,
     },
+    AccountStorageError(account_storage::Error),
 }
 
 impl core::fmt::Display for CommandError {
@@ -162,6 +165,9 @@ impl core::fmt::Display for CommandError {
                 project_name,
                 org_id,
             } => write!(f, "Cannot find project {}.{}", project_name, org_id),
+            CommandError::AccountStorageError(error) => {
+                write!(f, "Account storage error: {}", error)
+            }
         }
     }
 }


### PR DESCRIPTION
Completes the functionality required by #275 

Adds `cli account generate <name>` and `cli account list`.

**Note**:
`cli account generate <name>` generates a random key pair using `ed25519::Pair::generate()`, instead of us generating one from a given seed. I switched to this approach since we will no longer need the users to remember the seed. By doing so, we delegate security and form concerns to `ed25519::Pair::generate()` and offload our users from such unnecessary and critical responsibility.

 