### PR TITLE
Operate on account names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.1",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +826,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3518,10 +3551,13 @@ dependencies = [
  "async-std",
  "async-trait",
  "derive_more 0.99.3",
+ "directories",
  "futures 0.3.4",
  "hex",
  "pretty_env_logger",
  "radicle-registry-client",
+ "serde",
+ "serde_json",
  "sp-core",
  "structopt",
  "url 1.7.2",
@@ -3887,6 +3923,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,6 +4002,18 @@ checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64 0.11.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -118,11 +118,10 @@ use radicle-registry-client::{ed25519, CryptoPair};
 let alice = ed25519::Pair::from_string("//Alice", None);
 ```
 
-For cases where you are only interested in obtaining the [`SS58`][ss58-docs] address
-for a given seed (string), you can run:
+To obtain the [`SS58`][ss58-docs] address for your local accounts, you can run:
 
 ``` bash
-cargo run -p radicle-registry-cli -- show-address <seed>
+cargo run -p radicle-registry-cli -- account list
 ```
 
 The `radicle-registry-client::ed25519` module and the crypto traits are

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,11 +15,15 @@ radicle-registry-client = { version = "0.0.0", path = "../client" }
 async-std = { version = "1.4", features = ["attributes"] }
 async-trait = "0.1"
 derive_more = "0.99"
+directories = "2.0.2"
 futures = "0.3"
 hex = "0.4.0"
 pretty_env_logger = "0.3.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 structopt = "0.3"
 url = "1.7"
+
 
 [dependencies.sp-core]
 git = "https://github.com/paritytech/substrate"

--- a/cli/src/account_storage.rs
+++ b/cli/src/account_storage.rs
@@ -1,0 +1,120 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Accounts Storage
+//!
+//! Manages Accounts stored in the filesystem,
+//! providing ways to store and retrieve them.
+
+use directories::BaseDirs;
+use sp_core::serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+
+use std::io::Error as IOError;
+use std::path::PathBuf;
+
+/// AccountData
+///
+/// The data that is stored in the filesystem relative
+/// to an account. The account name is used as the key
+/// to this value, therefore not included here.
+#[derive(Serialize, Deserialize)]
+pub struct AccountData {
+    pub seed: Seed,
+}
+
+/// The seed from which an account's key pair
+/// can be determiniscally generated.
+type Seed = [u8; 32];
+
+#[derive(Debug)]
+pub enum Error {
+    /// An Account with the given name already exists
+    AlreadyExists(),
+    /// An IOError occurred
+    IOError(IOError),
+    /// A serde json Error occurred
+    JsonError(serde_json::Error),
+}
+
+/// Add an account to the storage.
+///
+/// Fails if an account with the given `name` already exists.
+/// It can also fail from IO and Serde Json errors.
+pub fn add(name: String, data: AccountData) -> Result<(), Error> {
+    let mut accounts = list()?;
+    if accounts.contains_key(&name) {
+        return Err(Error::AlreadyExists());
+    }
+
+    accounts.insert(name, data);
+    update(accounts)
+}
+
+/// List all the stored accounts
+///
+/// It can fail from IO and Serde Json errors.
+pub fn list() -> Result<HashMap<String, AccountData>, Error> {
+    let path_buf = get_or_create_path()?;
+    let file = File::open(path_buf.as_path()).map_err(Error::IOError)?;
+    let accounts: HashMap<String, AccountData> =
+        serde_json::from_reader(&file).map_err(Error::JsonError)?;
+    Ok(accounts)
+}
+
+fn update(accounts: HashMap<String, AccountData>) -> Result<(), Error> {
+    let path_buf = get_or_create_path()?;
+    let new_content = serde_json::to_string(&accounts).map_err(Error::JsonError)?;
+    std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(Error::IOError)
+}
+
+const FILE: &str = "accounts.json";
+
+// Get the path to the accounts file on disk.
+//
+// If the file does not yet exist, create it and initialize
+// it with an empty object so that it can be deserialized
+// as an empty HashMap<String, AccountData>.
+fn get_or_create_path() -> Result<PathBuf, Error> {
+    let dir = dir()?;
+    let path_buf = dir.join(FILE);
+    let path = path_buf.as_path();
+
+    if !path.exists() {
+        std::fs::write(path, b"{}").map_err(Error::IOError)?
+    }
+
+    Ok(path_buf)
+}
+
+fn dir() -> Result<PathBuf, Error> {
+    let dir = BaseDirs::new()
+        .unwrap()
+        .data_dir()
+        .join("radicle-registry-cli");
+    std::fs::create_dir_all(dir.clone()).map_err(Error::IOError)?;
+    Ok(dir)
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            Error::AlreadyExists() => write!(f, "An account with the given name already exists"),
+            Error::IOError(error) => write!(f, "An IO error occured: {}", error),
+            Error::JsonError(error) => write!(f, "A serde json error occured: {}", error),
+        }
+    }
+}

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -21,7 +21,6 @@ use crate::account_storage as storage;
 /// Account related commands
 #[derive(StructOpt, Debug, Clone)]
 pub enum Command {
-    Address(ShowAddress),
     Balance(ShowBalance),
     Generate(Generate),
     List(List),
@@ -32,31 +31,11 @@ pub enum Command {
 impl CommandT for Command {
     async fn run(&self, ctx: &CommandContext) -> Result<(), CommandError> {
         match self {
-            Command::Address(cmd) => cmd.run(ctx).await,
             Command::Balance(cmd) => cmd.run(ctx).await,
             Command::Generate(cmd) => cmd.run(ctx).await,
             Command::List(cmd) => cmd.run(ctx).await,
             Command::Transfer(cmd) => cmd.run(ctx).await,
         }
-    }
-}
-
-/// Show the SS58 address for the key pair derived from `seed`.
-///
-/// For more information on how the seed string is interpreted see
-/// <https://substrate.dev/rustdocs/v1.0/substrate_primitives/crypto/trait.Pair.html#method.from_string>.
-#[derive(StructOpt, Debug, Clone)]
-pub struct ShowAddress {
-    seed: String,
-}
-
-#[async_trait::async_trait]
-impl CommandT for ShowAddress {
-    async fn run(&self, _ctx: &CommandContext) -> Result<(), CommandError> {
-        let key_pair =
-            ed25519::Pair::from_string(format!("//{}", self.seed).as_str(), None).unwrap();
-        println!("SS58 address: {}", key_pair.public().to_ss58check());
-        Ok(())
     }
 }
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -16,12 +16,15 @@
 //! Define the commands supported by the CLI related to Accounts.
 
 use super::*;
+use crate::account_storage as storage;
 
 /// Account related commands
 #[derive(StructOpt, Debug, Clone)]
 pub enum Command {
     Address(ShowAddress),
     Balance(ShowBalance),
+    Generate(Generate),
+    List(List),
     Transfer(Transfer),
 }
 
@@ -31,16 +34,18 @@ impl CommandT for Command {
         match self {
             Command::Address(cmd) => cmd.run(ctx).await,
             Command::Balance(cmd) => cmd.run(ctx).await,
+            Command::Generate(cmd) => cmd.run(ctx).await,
+            Command::List(cmd) => cmd.run(ctx).await,
             Command::Transfer(cmd) => cmd.run(ctx).await,
         }
     }
 }
 
-#[derive(StructOpt, Debug, Clone)]
 /// Show the SS58 address for the key pair derived from `seed`.
 ///
 /// For more information on how the seed string is interpreted see
 /// <https://substrate.dev/rustdocs/v1.0/substrate_primitives/crypto/trait.Pair.html#method.from_string>.
+#[derive(StructOpt, Debug, Clone)]
 pub struct ShowAddress {
     seed: String,
 }
@@ -55,8 +60,8 @@ impl CommandT for ShowAddress {
     }
 }
 
-#[derive(StructOpt, Debug, Clone)]
 /// Show the balance of an account
+#[derive(StructOpt, Debug, Clone)]
 pub struct ShowBalance {
     #[structopt(
         value_name = "account",
@@ -75,8 +80,47 @@ impl CommandT for ShowBalance {
     }
 }
 
+/// Generate a local account and store it on disk.
+///
+/// Fail if there is already an account with the given `name`.
 #[derive(StructOpt, Debug, Clone)]
+pub struct Generate {
+    /// The name that uniquely identifies the account locally.
+    name: String,
+}
+
+#[async_trait::async_trait]
+impl CommandT for Generate {
+    async fn run(&self, _ctx: &CommandContext) -> Result<(), CommandError> {
+        let (_, seed) = ed25519::Pair::generate();
+        storage::add(self.name.clone(), storage::AccountData { seed })?;
+        println!("✓ Account generated successfully");
+        Ok(())
+    }
+}
+/// list all the local accounts
+#[derive(StructOpt, Debug, Clone)]
+pub struct List {}
+
+#[async_trait::async_trait]
+impl CommandT for List {
+    async fn run(&self, _ctx: &CommandContext) -> Result<(), CommandError> {
+        let accounts = storage::list()?;
+
+        println!("Accounts ({})", accounts.len());
+        for (name, data) in accounts {
+            println!("Account '{}'", name);
+            println!(
+                "\taddress: {}",
+                ed25519::Pair::from_seed(&data.seed).public().to_ss58check()
+            );
+        }
+        Ok(())
+    }
+}
+
 /// Transfer funds to recipient
+#[derive(StructOpt, Debug, Clone)]
 pub struct Transfer {
     #[structopt(parse(try_from_str = parse_account_id))]
     /// Recipient Account in SS58 address format.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,6 +18,8 @@
 use radicle_registry_client::*;
 use structopt::StructOpt;
 
+mod account_storage;
+
 mod command;
 use command::{account, org, other, project, user};
 
@@ -147,6 +149,7 @@ pub enum CommandError {
         project_name: ProjectName,
         org_id: OrgId,
     },
+    AccountStorageError(account_storage::Error),
 }
 
 impl core::fmt::Display for CommandError {
@@ -162,6 +165,9 @@ impl core::fmt::Display for CommandError {
                 project_name,
                 org_id,
             } => write!(f, "Cannot find project {}.{}", project_name, org_id),
+            CommandError::AccountStorageError(error) => {
+                write!(f, "Account storage error: {}", error)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #304 

- Receive account name instead of seed for `tx-author` cmd line option
- Drop `account address` command since `account list` supersedes that functionality

##Note

I was thinking of also changing `account balance` to receive either an account name or an SS58 address (as it does now). Doing so would make it more user friendly to get the balance of an owned account. I want to think more about this but I'd prefer to keep it aside from this PR.