### PR TITLE
Operate on account names

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,10 @@ use radicle-registry-client::{ed25519, CryptoPair};
 let alice = ed25519::Pair::from_string("//Alice", None);
 ```
 
-For cases where you are only interested in obtaining the [`SS58`][ss58-docs] address
-for a given seed (string), you can run:
+To obtain the [`SS58`][ss58-docs] address for your local accounts, you can run:
 
 ``` bash
-cargo run -p radicle-registry-cli -- show-address <seed>
+cargo run -p radicle-registry-cli -- account list
 ```
 
 The `radicle-registry-client::ed25519` module and the crypto traits are

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -21,7 +21,6 @@ use crate::account_storage;
 /// Account related commands
 #[derive(StructOpt, Debug, Clone)]
 pub enum Command {
-    Address(ShowAddress),
     Balance(ShowBalance),
     Generate(Generate),
     List(List),
@@ -32,31 +31,11 @@ pub enum Command {
 impl CommandT for Command {
     async fn run(&self, ctx: &CommandContext) -> Result<(), CommandError> {
         match self {
-            Command::Address(cmd) => cmd.run(ctx).await,
             Command::Balance(cmd) => cmd.run(ctx).await,
             Command::Generate(cmd) => cmd.run(ctx).await,
             Command::List(cmd) => cmd.run(ctx).await,
             Command::Transfer(cmd) => cmd.run(ctx).await,
         }
-    }
-}
-
-/// Show the SS58 address for the key pair derived from `seed`.
-///
-/// For more information on how the seed string is interpreted see
-/// <https://substrate.dev/rustdocs/v1.0/substrate_primitives/crypto/trait.Pair.html#method.from_string>.
-#[derive(StructOpt, Debug, Clone)]
-pub struct ShowAddress {
-    seed: String,
-}
-
-#[async_trait::async_trait]
-impl CommandT for ShowAddress {
-    async fn run(&self, _ctx: &CommandContext) -> Result<(), CommandError> {
-        let key_pair =
-            ed25519::Pair::from_string(format!("//{}", self.seed).as_str(), None).unwrap();
-        println!("SS58 address: {}", key_pair.public().to_ss58check());
-        Ok(())
     }
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -47,16 +47,12 @@ impl CommandLine {
 /// The accepted command-line options
 #[derive(StructOpt, Clone)]
 pub struct CommandLineOptions {
-    /// Value to derive the key pair for signing transactions.
-    /// See
-    /// <https://substrate.dev/rustdocs/v1.0/substrate_primitives/crypto/trait.Pair.html#method.from_string>
-    /// for information about the format of the string
+    /// The name of the local account to be used to sign transactions.
     #[structopt(
         long,
-        default_value = "//Alice",
         env = "RAD_TX_AUTHOR",
-        value_name = "key_pair",
-        parse(try_from_str = Self::parse_key_pair)
+        value_name = "account_name",
+        parse(try_from_str = Self::lookup_account)
     )]
     pub tx_author: ed25519::Pair,
 
@@ -76,8 +72,12 @@ pub struct CommandLineOptions {
 }
 
 impl CommandLineOptions {
-    fn parse_key_pair(s: &str) -> Result<ed25519::Pair, String> {
-        ed25519::Pair::from_string(s, None).map_err(|err| format!("{:?}", err))
+    fn lookup_account(name: &str) -> Result<ed25519::Pair, String> {
+        let accounts = account_storage::list().map_err(|e| format!("{}", e))?;
+        match accounts.get(&name.to_string()) {
+            Some(account) => Ok(ed25519::Pair::from_seed(&account.seed)),
+            None => Err(format!("Could not find local account named '{}'", name)),
+        }
     }
 }
 


### PR DESCRIPTION
Closes #304 

- Receive account name instead of seed for `tx-author` cmd line option
- Drop `account address` command since `account list` supersedes that functionality

## Notes

1. No more `//Alice`, _the_ account with funds. We need to think about how we will survive like this. (#292)

2. I was thinking of also changing `account balance` to receive either an account name or an SS58 address (as it does now). Doing so would make it more user friendly to get the balance of an owned account. I want to think more about this but I'd prefer to keep it aside from this PR.
