### PR TITLE
Implement std Error for client::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,7 @@ dependencies = [
  "async-trait",
  "derive_more 0.15.0",
  "env_logger 0.7.1",
+ "failure",
  "frame-support",
  "frame-system",
  "futures 0.1.29",
@@ -3609,6 +3610,7 @@ dependencies = [
  "sp-state-machine",
  "sp-timestamp",
  "sp-transaction-pool",
+ "thiserror",
  "tokio 0.1.22",
  "url 1.7.2",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,6 +16,7 @@ radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
 async-trait = "0.1"
 derive_more = "0.15"
 env_logger = "0.7"
+failure = "0.1.7"
 futures01 = { package = "futures", version = "0.1" }
 futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core-client = { version = "14.0", features = ["ws"] }
@@ -23,6 +24,7 @@ lazy_static = "1.4"
 log = "0.4"
 parity-scale-codec = "1.0"
 serde = "1.0"
+thiserror = "1.0.14"
 tokio = "0.1"
 url = "1.7"
 

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -21,7 +21,7 @@ use sp_runtime::DispatchError;
 
 pub use radicle_registry_core::message::*;
 
-/// Indicates that parsing the events into the approriate message result failed.
+/// Indicates that parsing the events into the appropriate message result failed.
 type EventParseError = String;
 
 /// Trait implemented for every runtime message


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-registry/issues/226

There are a few changes in the API to make it more conventional. @xla please confirm if they are OK with you. 