### PR TITLE
Cli/fix leaked abstraction

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -23,8 +23,7 @@ pub mod account_storage;
 mod command;
 use command::{account, org, other, project, user};
 
-/// The type that captures the command line,
-/// composed by a [Command] and [CommandLineOptions].
+/// The type that captures the command line.
 #[derive(StructOpt, Clone)]
 #[structopt(max_term_width = 80)]
 pub struct CommandLine {


### PR DESCRIPTION
Fixes #314 #283 #281 


As explained in #283, have each command define the options that it needs to run.
Done by flattening shared options, one for the network and the other for the transaction-related options.

