### PR TITLE
cli: use thiserror for CommandError Display

### DIFF
--- a/cli/src/account_storage.rs
+++ b/cli/src/account_storage.rs
@@ -45,37 +45,36 @@ pub enum Error {
 
     /// Failed to write to the accounts file
     #[error("Failed to write to the accounts file: {0}")]
-    FailedWrite(WritingError),
+    FailedWrite(#[from] WritingError),
 
     /// Failed to read the accounts file
     #[error("Failed to read the accounts file: {0}")]
-    FailedRead(ReadingError),
+    FailedRead(#[from] ReadingError),
 }
-
 
 /// Possible errors when writing to the accounts file.
 #[derive(Debug, ThisError)]
 pub enum WritingError {
-    #[error("{0}")]
+    #[error(transparent)]
     IO(IOError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Serialization(serde_json::Error),
 }
 
 /// Possible errors when reading the accounts file.
 #[derive(Debug, ThisError)]
 pub enum ReadingError {
-    #[error("{0}")]
+    #[error(transparent)]
     IO(IOError),
 
-    #[error("{0}")]
+    #[error(transparent)]
     Deserialization(serde_json::Error),
 }
 
 /// Add an account to the storage.
 ///
-/// Fails if an account with the given `name` already exists_.
+/// Fails if an account with the given `name` already exists.
 /// It can also fail from IO and Serde Json errors.
 pub fn add(name: String, data: AccountData) -> Result<(), Error> {
     let mut accounts = list()?;
@@ -87,25 +86,22 @@ pub fn add(name: String, data: AccountData) -> Result<(), Error> {
     update(accounts)
 }
 
-/// List all the stored accountsr
+/// List all the stored accounts.
 ///
 /// It can fail from IO and Serde Json errors.
 pub fn list() -> Result<HashMap<String, AccountData>, Error> {
     let path_buf = get_or_create_path()?;
-    let file = File::open(path_buf.as_path())
-        .map_err(|e| Error::FailedRead(ReadingError::IO(e)))?;
+    let file = File::open(path_buf.as_path()).map_err(ReadingError::IO)?;
     let accounts: HashMap<String, AccountData> =
-        serde_json::from_reader(&file)
-            .map_err(|e| Error::FailedRead(ReadingError::Deserialization(e)))?;
+        serde_json::from_reader(&file).map_err(ReadingError::Deserialization)?;
     Ok(accounts)
 }
 
 fn update(accounts: HashMap<String, AccountData>) -> Result<(), Error> {
     let path_buf = get_or_create_path()?;
-    let new_content = serde_json::to_string(&accounts)
-        .map_err(|e| Error::FailedWrite(WritingError::Serialization(e)))?;
-    std::fs::write(path_buf.as_path(), new_content.as_bytes())
-        .map_err(|e| Error::FailedWrite(WritingError::IO(e)))
+    let new_content = serde_json::to_string(&accounts).map_err(WritingError::Serialization)?;
+    std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(WritingError::IO)?;
+    Ok(())
 }
 
 const FILE: &str = "accounts.json";
@@ -121,8 +117,7 @@ fn get_or_create_path() -> Result<PathBuf, Error> {
     let path = path_buf.as_path();
 
     if !path.exists() {
-        std::fs::write(path, b"{}")
-            .map_err(|e| Error::FailedWrite(WritingError::IO(e)))?;
+        std::fs::write(path, b"{}").map_err(WritingError::IO)?;
     }
 
     Ok(path_buf)
@@ -133,6 +128,6 @@ fn dir() -> Result<PathBuf, Error> {
         .unwrap()
         .data_dir()
         .join("radicle-registry-cli");
-    std::fs::create_dir_all(&dir).map_err(|e| Error::FailedRead(ReadingError::IO(e)))?;
+    std::fs::create_dir_all(&dir).map_err(ReadingError::IO)?;
     Ok(dir)
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -140,6 +140,6 @@ pub enum CommandError {
         org_id: OrgId,
     },
 
-    #[error("Account storage error: {0}")]
+    #[error("{0}")]
     AccountStorageError(account_storage::Error),
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,6 +19,7 @@
 
 use radicle_registry_client::*;
 use structopt::StructOpt;
+use thiserror::Error as ThisError;
 
 pub mod account_storage;
 
@@ -119,39 +120,26 @@ pub trait CommandT {
 /// Error returned by [CommandT::run].
 ///
 /// Implements [From] for client errors.
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, derive_more::From, ThisError)]
 pub enum CommandError {
+    #[error("Client error: {0}")]
     ClientError(Error),
+
+    #[error("Transaction {tx_hash:?} failed in block {block_hash:?}")]
     FailedTransaction {
         tx_hash: TxHash,
         block_hash: BlockHash,
     },
-    OrgNotFound {
-        org_id: OrgId,
-    },
+
+    #[error("Cannot find org {org_id:?}")]
+    OrgNotFound { org_id: OrgId },
+
+    #[error("Cannot find project {project_name:?}.{org_id:?}")]
     ProjectNotFound {
         project_name: ProjectName,
         org_id: OrgId,
     },
-    AccountStorageError(account_storage::Error),
-}
 
-impl core::fmt::Display for CommandError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        match self {
-            CommandError::ClientError(error) => write!(f, "Client error: {}", error),
-            CommandError::FailedTransaction {
-                tx_hash,
-                block_hash,
-            } => write!(f, "Transaction {} failed in block {}", tx_hash, block_hash),
-            CommandError::OrgNotFound { org_id } => write!(f, "Cannot find org {}", org_id),
-            CommandError::ProjectNotFound {
-                project_name,
-                org_id,
-            } => write!(f, "Cannot find project {}.{}", project_name, org_id),
-            CommandError::AccountStorageError(error) => {
-                write!(f, "Account storage error: {}", error)
-            }
-        }
-    }
+    #[error("Account storage error: {0}")]
+    AccountStorageError(account_storage::Error),
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -119,27 +119,27 @@ pub trait CommandT {
 
 /// Error returned by [CommandT::run].
 ///
-/// Implements [From] for client errors.
-#[derive(Debug, derive_more::From, ThisError)]
+/// Implements [From] for client errors and [account_storage] errors.
+#[derive(Debug, ThisError)]
 pub enum CommandError {
     #[error("Client error: {0}")]
-    ClientError(Error),
+    ClientError(#[from] Error),
 
-    #[error("Transaction {tx_hash:?} failed in block {block_hash:?}")]
+    #[error("Transaction {tx_hash} failed in block {block_hash}")]
     FailedTransaction {
         tx_hash: TxHash,
         block_hash: BlockHash,
     },
 
-    #[error("Cannot find org {org_id:?}")]
+    #[error("Cannot find org {org_id}")]
     OrgNotFound { org_id: OrgId },
 
-    #[error("Cannot find project {project_name:?}.{org_id:?}")]
+    #[error("Cannot find project {project_name}.{org_id}")]
     ProjectNotFound {
         project_name: ProjectName,
         org_id: OrgId,
     },
 
     #[error("{0}")]
-    AccountStorageError(account_storage::Error),
+    AccountStorageError(#[from] account_storage::Error),
 }


### PR DESCRIPTION
Closes #308 

I thought we had more error types in the CLI in need of this but it turns out that only `CommandError` was missing.