### PR TITLE
cli: drop '_TX_' from tx-related options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 ### Breaking changes
 
+* cli: Drop `_TX_` from the environment options
 * cli: group and clean commands by domain and rename options
 * Add `fee` to the Client and CLI APIs
 * Normalize core::message and cli commands parameters

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -65,7 +65,7 @@ pub struct TxOptions {
     /// The name of the local account to be used to sign transactions.
     #[structopt(
         long,
-        env = "RAD_TX_AUTHOR",
+        env = "RAD_AUTHOR",
         value_name = "account_name",
         parse(try_from_str = lookup_account)
     )]
@@ -73,7 +73,7 @@ pub struct TxOptions {
 
     /// Fee that will be charged to submit transactions.
     /// The higher the fee, the higher the priority of a transaction.
-    #[structopt(long, default_value = "1", env = "RAD_TX_FEE", value_name = "fee")]
+    #[structopt(long, default_value = "1", env = "RAD_FEE", value_name = "fee")]
     pub fee: Balance,
 }
 


### PR DESCRIPTION
It's unnecessary and now the env vars was RAD_TX_XYZ while the cmd line options are just --xyz.

Change motived by writing the docs to the FFnet.