### PR TITLE
Improved runtime API interface

### DIFF
--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -23,7 +23,7 @@ use sp_runtime::{traits::Hash as _, BuildStorage as _, Digest};
 use sp_state_machine::backend::Backend as _;
 
 use radicle_registry_runtime::{
-    registry, AccountId, BalancesConfig, Executive, GenesisConfig, Hash, Hashing, Header, Runtime,
+    registry, runtime_api, AccountId, BalancesConfig, GenesisConfig, Hash, Hashing, Header, Runtime,
 };
 
 use crate::backend;
@@ -115,25 +115,25 @@ impl backend::Backend for Emulator {
         };
 
         let (new_tip_header, events) = state.test_ext.execute_with(move || {
-            Executive::initialize_block(&new_tip_header_init);
+            runtime_api::initialize_block(&new_tip_header_init);
 
             let inherent_data = self.inherent_data_providers.create_inherent_data().unwrap();
-            let inherents = radicle_registry_runtime::inherent_extrinsics(inherent_data);
+            let inherents = runtime_api::inherent_extrinsics(inherent_data);
             for inherent in inherents {
-                let _apply_result = Executive::apply_extrinsic(inherent).unwrap();
+                let _apply_result = runtime_api::apply_extrinsic(inherent).unwrap();
             }
 
             let event_start_index = frame_system::Module::<Runtime>::event_count();
             // We ignore the dispatch result. It is provided through the system event
             // TODO Pass on apply errors instead of unwrapping.
-            let _apply_result = Executive::apply_extrinsic(extrinsic).unwrap();
+            let _apply_result = runtime_api::apply_extrinsic(extrinsic).unwrap();
             let events = frame_system::Module::<Runtime>::events()
                 .into_iter()
                 .skip(event_start_index as usize)
                 .map(|event_record| event_record.event)
                 .collect::<Vec<Event>>();
 
-            let header = Executive::finalize_block();
+            let header = runtime_api::finalize_block();
             (header, events)
         });
 

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::registry::store;
-use crate::{AccountId, Call, DispatchError, RegistryCall};
+use crate::{AccountId, Call, DispatchError, Runtime};
 use radicle_registry_core::*;
 
 use frame_support::storage::{StorageMap as _, StorageValue as _};
@@ -22,6 +22,8 @@ use frame_support::traits::{Currency, ExistenceRequirement, Imbalance, WithdrawR
 use sp_runtime::Permill;
 
 type NegativeImbalance = <crate::Balances as Currency<AccountId>>::NegativeImbalance;
+
+type RegistryCall = crate::registry::Call<Runtime>;
 
 /// Share of a transaction fee that is burned rather than credited to the block author.
 const BURN_SHARE: Permill = Permill::from_percent(1);

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -1,0 +1,171 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Implements Substrate runtime APIs and provide a function based interface for the runtime APIs.
+use frame_support::{ensure, fail, traits::Randomness};
+use sp_core::OpaqueMetadata;
+use sp_runtime::traits::Block as BlockT;
+use sp_runtime::{
+    transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
+    ApplyExtrinsicResult,
+};
+
+use super::{
+    registry, AllModules, Block, Call, Header, InherentDataExt, RandomnessCollectiveFlip, Runtime,
+    RuntimeVersion, UncheckedExtrinsic, VERSION,
+};
+
+type Executive = frame_executive::Executive<
+    Runtime,
+    Block,
+    frame_system::ChainContext<Runtime>,
+    Runtime,
+    AllModules,
+>;
+
+pub const VERSIONS: sp_version::ApisVec = RUNTIME_API_VERSIONS;
+
+/// See [sp_api::Core::initialize_block]
+pub fn initialize_block(header: &Header) {
+    Executive::initialize_block(header)
+}
+
+/// See [sp_block_builder::BlockBuilder::inherent_extrinsics].
+pub fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<UncheckedExtrinsic> {
+    data.create_extrinsics()
+}
+
+/// See [sp_block_builder::BlockBuilder::apply_extrinsic].
+pub fn apply_extrinsic(extrinsic: UncheckedExtrinsic) -> ApplyExtrinsicResult {
+    validate_extrinsic_call(&extrinsic)?;
+    Executive::apply_extrinsic(extrinsic)
+}
+
+/// See [sp_block_builder::BlockBuilder::finalize_block].
+pub fn finalize_block() -> Header {
+    Executive::finalize_block()
+}
+
+const SIGNED_INHERENT_CALL_ERROR: InvalidTransaction = InvalidTransaction::Custom(1);
+const FOBIDDEN_CALL_ERROR: InvalidTransaction = InvalidTransaction::Custom(2);
+const UNSGINED_CALL_ERROR: InvalidTransaction = InvalidTransaction::Custom(3);
+
+/// Validate that the call of the extrinsic is allowed.
+///
+/// * We forbid calls reserved for inherents when the extrinsic is not signed.
+/// * We forbid any calls to the [super::Balances] or [super::System] module.
+/// * We ensure that the extrinsic is signed for non-inherent calls.
+///
+fn validate_extrinsic_call(xt: &UncheckedExtrinsic) -> Result<(), InvalidTransaction> {
+    match xt.function {
+        // Inherents are only allowed if they are unsigned.
+        Call::Timestamp(_) | Call::Registry(registry::Call::set_block_author(_)) => {
+            ensure!(xt.signature.is_none(), SIGNED_INHERENT_CALL_ERROR)
+        }
+
+        // Forbidden internals.
+        Call::Balances(_) | Call::System(_) => fail!(FOBIDDEN_CALL_ERROR),
+
+        // Impossible cases that cannot be constructed.
+        Call::RandomnessCollectiveFlip(_) => fail!(FOBIDDEN_CALL_ERROR),
+
+        // Allowed calls for signed extrinsics.
+        Call::Registry(_) | Call::Sudo(_) => ensure!(xt.signature.is_some(), UNSGINED_CALL_ERROR),
+    }
+
+    Ok(())
+}
+
+sp_api::impl_runtime_apis! {
+    impl sp_api::Core<Block> for Runtime {
+        fn version() -> RuntimeVersion {
+            VERSION
+        }
+
+        fn execute_block(block: Block) {
+            Executive::execute_block(block)
+        }
+
+        fn initialize_block(header: &<Block as BlockT>::Header) {
+            initialize_block(header);
+        }
+    }
+
+    impl sp_api::Metadata<Block> for Runtime {
+        fn metadata() -> OpaqueMetadata {
+            Runtime::metadata().into()
+        }
+    }
+
+    impl sp_block_builder::BlockBuilder<Block> for Runtime {
+        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+            apply_extrinsic(extrinsic)
+        }
+
+        fn finalize_block() -> <Block as BlockT>::Header {
+            finalize_block()
+        }
+
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+            inherent_extrinsics(data)
+        }
+
+        fn check_inherents(
+            block: Block,
+            data: sp_inherents::InherentData,
+        ) -> sp_inherents::CheckInherentsResult {
+            data.check_extrinsics(&block)
+        }
+
+        fn random_seed() -> <Block as BlockT>::Hash {
+            RandomnessCollectiveFlip::random_seed()
+        }
+    }
+
+    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+        fn validate_transaction(source: TransactionSource, tx: <Block as BlockT>::Extrinsic) -> TransactionValidity {
+            validate_extrinsic_call(&tx)?;
+            Executive::validate_transaction(source, tx)
+        }
+    }
+
+    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+        fn offchain_worker(header: &<Block as BlockT>::Header) {
+            Executive::offchain_worker(header)
+        }
+    }
+
+    // An implementation for the `SessionKeys` runtime API is required by the types
+    // of [sc_service::ServiceBuilder]. However, the implementation is otherwise unused
+    // and has no effect on the behavior of the runtime. Hence we implement a dummy
+    // version.
+    impl sp_session::SessionKeys<Block> for Runtime {
+        fn generate_session_keys(_seed: Option<Vec<u8>>) -> Vec<u8> {
+            Default::default()
+        }
+
+        fn decode_session_keys(
+            _encoded: Vec<u8>,
+        ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
+            None
+        }
+    }
+
+    impl sp_consensus_pow::TimestampApi<Block, u64> for Runtime {
+        fn timestamp() -> u64 {
+            pallet_timestamp::Module::<Runtime>::get()
+        }
+    }
+}


### PR DESCRIPTION
Before, the emulator was duplicating code from the runtime API implementations. We now offer this code from a `runtime_api` module from the runtime. We also move everything related to the Substrate runtime implementation (that is the `impl_runtime_apis!` call ) to this module to improve encapsulation.