### PR TITLE
Hardcode a chain spec in a built node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,6 +3698,7 @@ name = "radicle-registry-node"
 version = "0.0.0"
 dependencies = [
  "blake3",
+ "cfg-if",
  "ctrlc",
  "derive_more 0.15.0",
  "env_logger 0.7.1",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -38,6 +38,8 @@ Running development node
 ./scripts/run-dev-node
 ~~~
 
+The node is built for the `dev` chain. In order to
+
 The build script purges the chain data before running to avoid consensus issues.
 
 To purge the chain state manually run
@@ -46,6 +48,44 @@ To purge the chain state manually run
 ./scripts/run-dev-node purge-chain
 ~~~
 
+Building a node
+---------------
+
+In order to build a node run
+
+~~~
+GENESIS_CHAIN=<chain> cargo build -p radicle-registry-node --release
+~~~
+
+The `<chain>` parameter defines, for which chain the node is going to be built.
+It must be one of these values:
+
+### `dev`
+
+This chain is intended for local development.
+The node runs an isolated network with a dummy proof-of-work.
+
+### `local-devnet`
+
+This chain is intended for local development.
+The node runs only on a local cluster of nodes, but it has a real proof-of-work.
+See `./local-devnet/README.md` for more information.
+
+### `devnet`
+
+We host a devnet that you can connect to. To join you need to use the most
+recent pre-built binary (see “Getting the node”).
+
+We are frequently resetting the devnet blockchain. If you local node is not
+syncing blocks download the most recent version and run `radicle-registry-node purge-chain`.
+
+### `ffnet`
+
+We host a ffnet that you can connect to. To join you need to use the most
+recent pre-built binary (see “Getting the node”).
+
+It's more stable than the `devnet`, but breaking changes may occur frequently requiring updating
+and purging the node with `radicle-registry-node purge-chain`.
 
 Packages
 --------

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ To build the node from source see [`DEVELOPING.md`][dev-manual].
 Running the node
 ----------------
 
-To run a node you need to specify the chain
+You can run the node with
 ~~~
-radicle-registry-node --chain devnet
+radicle-registry-node
 ~~~
 
-See below for more information on the different chains.
+The node will use the chain specified during its compilation.
 
 For more information use the `--help` flag.
 
@@ -63,25 +63,6 @@ You can adjust the global log level and the log level for specific targets with
 the [`RUST_LOG` environment variable][rust-log-docs].
 
 [rust-log-docs]: https://docs.rs/env_logger/0.7.1/env_logger/#enabling-logging
-
-### Dev
-
-The `dev` chain is intended for local development. The node runs an isolated
-network with a dummy proof-of-work.
-
-### Devnet
-
-We host a devnet that you can connect to. To join you need to use the most
-recent pre-built binary (see “Getting the node”).
-
-~~~
-radicle-registry-node --chain devnet
-~~~
-
-We are frequently resetting the devnet blockchain. If you local node is not
-syncing blocks download the most recent version and run `radicle-registry-node
---chain devnet purge-chain`.
-
 
 Using the Client
 ----------------

--- a/ci/run
+++ b/ci/run
@@ -45,6 +45,7 @@ echo "--- cargo fmt"
 time cargo fmt --all -- --check
 
 export RUSTFLAGS="-D warnings"
+export GENESIS_CHAIN=ffnet
 
 echo "--- cargo clippy"
 cargo clippy --workspace --all-targets --release -- -D clippy::all
@@ -61,7 +62,6 @@ cargo build --workspace --all-targets --release
 echo "--- cargo test"
 echo "Starting radicle-registry-node"
 RUST_LOG=error ./target/release/radicle-registry-node \
-  --chain dev \
   --mine 5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq \
   --data-path /tmp/radicle-registry \
   &

--- a/local-devnet/README.md
+++ b/local-devnet/README.md
@@ -5,7 +5,7 @@ This directory provides tools to run and experiment with a local devnet.
 
 To run the devnet you need to build the registry node with
 ```bash
-./scripts/build-dev-node
+GENESIS_CHAIN=local-devnet cargo build -p radicle-registry-node --release
 ```
 Then you can start the network with `docker-compose up`
 
@@ -15,7 +15,7 @@ Overview
 * Devnet consists of three miner nodes.
 * Chain data of nodes is persisted in Docker volumes.
 * We expose the RPC API of the first node on the standard RPC API port.
-* See `local_devnet()` for chain spec in `../node/src/chain_spec.rs`.
+* See chain spec details in file `../node/src/chain_spec.rs`, in function `chain_spec()` for `#[cfg(genesis_chain="local-devnet")]`.
 * You need to build the node using a target that is compatible with Ubuntu 19.10
   (Eoan).
 

--- a/local-devnet/start-node.sh
+++ b/local-devnet/start-node.sh
@@ -16,7 +16,6 @@ block_author=5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq
 exec /usr/local/bin/radicle-registry-node \
   --data-path /data \
   --name "$NODE_NAME" \
-  --chain local-devnet \
   --mine "$block_author" \
   --unsafe-rpc-external \
   --prometheus-external \

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,6 +16,7 @@ name = "radicle-registry-node"
 radicle-registry-runtime = { version = "0.0.0", path = "../runtime" }
 
 blake3 = "0.2.1"
+cfg-if = "0.1.10"
 derive_more = "0.15.0"
 env_logger = "0.7"
 exit-future = "0.1.4"

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,5 +1,19 @@
 use vergen::{generate_cargo_keys, ConstantsFlags};
 
+const GENESIS_CHAIN_ENV: &str = "GENESIS_CHAIN";
+const GENESIS_CHAIN_CFG: &str = "genesis_chain";
+
 fn main() {
     generate_cargo_keys(ConstantsFlags::SHA_SHORT).unwrap();
+    set_genesis_chain_cfg();
+}
+
+fn set_genesis_chain_cfg() {
+    if let Ok(genesis_chain) = std::env::var(GENESIS_CHAIN_ENV) {
+        println!(
+            "cargo:rustc-cfg={}=\"{}\"",
+            GENESIS_CHAIN_CFG, genesis_chain
+        );
+    }
+    println!("cargo:rerun-if-env-changed={}", GENESIS_CHAIN_ENV);
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,17 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Provides [Chain] and [ChainSpec]s for various chains we want to run.
-//!
-//! Available chain specs
-//! * [dev] for runnning a single node locally and develop against it.
-//! * [local_devnet] for runnning a cluster of three nodes locally.
+//! Provides chain spec. See [chain_spec] for more details.
+
 use crate::pow::config::Config as PowAlgConfig;
 use radicle_registry_runtime::{
     AccountId, BalancesConfig, GenesisConfig, SudoConfig, SystemConfig,
 };
 use sc_service::GenericChainSpec;
-use sp_core::{Pair, Public};
+use sp_core::{crypto::CryptoType, Pair};
 use std::convert::TryFrom;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -31,125 +28,111 @@ pub type ChainSpec = GenericChainSpec<GenesisConfig>;
 
 const WASM_BINARY: &[u8] = include_bytes!("../../runtime/genesis_runtime.wasm");
 
-/// Possible chains.
+/// Provides chain specs for various chains we want to run.
 ///
-/// Use [Chain::spec] to get the corresponding [ChainSpec].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Chain {
-    Dev,
-    DevnetLocal,
-    Devnet,
-}
-
-impl Chain {
-    pub fn spec(&self) -> ChainSpec {
-        match self {
-            Chain::Dev => dev(),
-            Chain::DevnetLocal => local_devnet(),
-            Chain::Devnet => devnet(),
+/// Chain is picked automatically based on the value of the `cfg` flag `genesis_chain`:
+/// * 'dev' for runnning a single node locally and develop against it
+/// * 'local_devnet' for runnning a cluster of nodes locally
+/// * 'devnet' for runnning a development network of nodes
+/// * 'ffnet' for runnning a "friends and family" network of nodes
+/// If none of the above values are set, the compilation will fail.
+pub fn chain_spec() -> ChainSpec {
+    cfg_if::cfg_if! {
+        if #[cfg(genesis_chain="dev")] {
+            GenericChainSpec::from_genesis(
+                "Development, isolated node",
+                "dev",
+                genesis_config,
+                vec![], // boot nodes
+                None, // telemetry endpoints
+                Some("dev"), // protocol_id
+                Some(sc_service::Properties::try_from(PowAlgConfig::Dummy).unwrap()),
+                None, // no extensions
+            )
+        } else if #[cfg(genesis_chain="local-devnet")] {
+            GenericChainSpec::from_genesis(
+                "local devnet, isolated on one machine",
+                "local-devnet",
+                genesis_config,
+                vec![], // boot nodes
+                None,   // telemetry endpoints
+                Some("local-devnet"), // protocol_id
+                Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
+                None, // no extensions
+            )
+        } else if #[cfg(genesis_chain="devnet")] {
+            let boot_node = // From key 000...001
+                "/ip4/35.233.120.254/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR"
+                    .parse()
+                    .expect("Parsing a genesis peer address failed");
+            GenericChainSpec::from_genesis(
+                "devnet",
+                "devnet",
+                genesis_config,
+                vec![boot_node], // boot nodes
+                None, // telemetry endpoints
+                Some("devnet"), // protocol_id
+                Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
+                None, // no extensions
+            )
+        } else if #[cfg(genesis_chain="ffnet")] {
+            GenericChainSpec::from_genesis(
+                "ffnet",
+                "ffnet",
+                genesis_config,
+                vec![], // boot nodes
+                None, // telemetry endpoints
+                Some("ffnet"), // protocol_id
+                Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
+                None, // no extensions
+            )
+        } else {
+            compile_error! {
+                "Environment variable GENESIS_CHAIN must be set to: \
+                'dev', 'local-devnet', 'devnet' or 'ffnet'"
+            }
         }
     }
 }
 
-pub fn dev() -> ChainSpec {
-    GenericChainSpec::from_genesis(
-        "Development, isolated node",
-        "dev",
-        dev_genesis_config,
-        vec![], // boot nodes
-        None,   // telemetry endpoints
-        // protocol_id
-        Some("dev"),
-        Some(sc_service::Properties::try_from(PowAlgConfig::Dummy).unwrap()),
-        None, // no extensions
-    )
-}
+cfg_if::cfg_if! {
+    if #[cfg(any(
+            genesis_chain="dev",
+            genesis_chain="local-devnet",
+            genesis_chain="devnet",
+            genesis_chain="ffnet",
+        ))] {
 
-fn dev_genesis_config() -> GenesisConfig {
-    let endowed_accounts = vec![
-        get_from_seed::<AccountId>("Alice"),
-        get_from_seed::<AccountId>("Bob"),
-        get_from_seed::<AccountId>("Alice//stash"),
-        get_from_seed::<AccountId>("Bob//stash"),
-    ];
-    let root_key = get_from_seed::<AccountId>("Alice");
-    GenesisConfig {
-        system: Some(SystemConfig {
-            code: WASM_BINARY.to_vec(),
-            changes_trie_config: Default::default(),
-        }),
-        pallet_balances: Some(BalancesConfig {
-            balances: endowed_accounts
-                .iter()
-                .cloned()
-                .map(|k| (k, 1 << 60))
-                .collect(),
-        }),
-        pallet_sudo: Some(SudoConfig { key: root_key }),
+        fn genesis_config() -> GenesisConfig {
+            let endowed_accounts = vec![
+                account_pub_key("Alice"),
+                account_pub_key("Bob"),
+                account_pub_key("Alice//stash"),
+                account_pub_key("Bob//stash"),
+            ];
+            let root_key = account_pub_key("Alice");
+            GenesisConfig {
+                system: Some(SystemConfig {
+                    code: WASM_BINARY.to_vec(),
+                    changes_trie_config: Default::default(),
+                }),
+                pallet_balances: Some(BalancesConfig {
+                    balances: endowed_accounts
+                        .iter()
+                        .cloned()
+                        .map(|k| (k, 1 << 60))
+                        .collect(),
+                }),
+                pallet_sudo: Some(SudoConfig { key: root_key }),
+            }
+        }
+
     }
 }
 
-pub fn devnet() -> ChainSpec {
-    GenericChainSpec::from_genesis(
-        "devnet",
-        "devnet",
-        devnet_genesis_config,
-        // boot nodes
-        // From key 000...001
-        vec![
-            "/ip4/35.233.120.254/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR"
-                .parse()
-                .expect("Parsing a genesis peer address failed"),
-        ],
-        None, // telemetry endpoints
-        // protocol_id
-        Some("devnet"),
-        Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
-        None, // no extensions
-    )
-}
-
-pub fn local_devnet() -> ChainSpec {
-    GenericChainSpec::from_genesis(
-        "local devnet, isolated on one machine",
-        "local-devnet",
-        devnet_genesis_config,
-        vec![], // boot nodes
-        None,   // telemetry endpoints
-        // protocol_id
-        Some("local-devnet"),
-        Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
-        None, // no extensions
-    )
-}
-
-fn devnet_genesis_config() -> GenesisConfig {
-    let endowed_accounts = vec![
-        get_from_seed::<AccountId>("Alice"),
-        get_from_seed::<AccountId>("Bob"),
-        get_from_seed::<AccountId>("Alice//stash"),
-        get_from_seed::<AccountId>("Bob//stash"),
-    ];
-    let root_key = get_from_seed::<AccountId>("Alice");
-    GenesisConfig {
-        system: Some(SystemConfig {
-            code: WASM_BINARY.to_vec(),
-            changes_trie_config: Default::default(),
-        }),
-        pallet_balances: Some(BalancesConfig {
-            balances: endowed_accounts
-                .iter()
-                .cloned()
-                .map(|k| (k, 1 << 60))
-                .collect(),
-        }),
-        pallet_sudo: Some(SudoConfig { key: root_key }),
-    }
-}
-
-/// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
+/// Helper function to generate a crypto pair from the seed
+fn account_pub_key(seed: &str) -> <<AccountId as CryptoType>::Pair as Pair>::Public {
+    <AccountId as CryptoType>::Pair::from_string(&format!("//{}", seed), None)
+        .expect("Parsing the account key pair seed failed")
         .public()
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -19,8 +19,6 @@ use sc_cli::{RunCmd, Subcommand};
 use sc_network::config::MultiaddrWithPeerId;
 use structopt::{clap, StructOpt};
 
-use crate::chain_spec::Chain;
-
 /// Command line arguments.
 ///
 /// Implements [StructOpt] for parsing.
@@ -28,16 +26,6 @@ use crate::chain_spec::Chain;
 pub struct Arguments {
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
-
-    /// Chain to connect to.
-    #[structopt(
-        long,
-        default_value = "dev",
-        value_name = "CHAIN",
-        parse(try_from_str = parse_chain),
-        possible_values = &["dev", "local-devnet", "devnet"]
-    )]
-    pub chain: Chain,
 
     /// Human-readable name for this node to use for telemetry'
     #[structopt(long, value_name = "NAME")]
@@ -142,19 +130,6 @@ impl Arguments {
             prometheus_external,
             ..run_cmd
         }
-    }
-}
-
-// NOTE Update `possible_values` in the structopt attribute if something is added here.
-fn parse_chain(name: &str) -> Result<Chain, String> {
-    if name == "dev" {
-        Ok(Chain::Dev)
-    } else if name == "local-devnet" {
-        Ok(Chain::DevnetLocal)
-    } else if name == "devnet" {
-        Ok(Chain::Devnet)
-    } else {
-        Err(format!("Invalid chain {}", name))
     }
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -25,7 +25,7 @@ pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
     let args = cli::Arguments::from_args(&version);
     let mut config = sc_service::Configuration::from_version(&version);
 
-    let chain_spec = args.chain.spec();
+    let chain_spec = crate::chain_spec::chain_spec();
     let spec_factory = |_: &str| Ok(Box::new(chain_spec) as Box<_>);
 
     let opt_block_author = args.mine;

--- a/scripts/build-dev-node
+++ b/scripts/build-dev-node
@@ -5,6 +5,6 @@
 
 set -euo pipefail
 
-cargo build -p radicle-registry-node --release
-(set +o pipefail;  yes | ./target/release/radicle-registry-node --chain dev purge-chain)
+GENESIS_CHAIN=dev cargo build -p radicle-registry-node --release
+(set +o pipefail;  yes | ./target/release/radicle-registry-node purge-chain)
 echo "Node binary ./target/release/radicle-registry-node was successfully built"

--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -5,4 +5,4 @@ set -euo pipefail
 # Adress for the seed string //Mine
 block_author=5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq
 radicle_registry_node=./target/release/radicle-registry-node
-exec $radicle_registry_node "$@" --chain dev --mine "$block_author"
+exec $radicle_registry_node "$@" --mine "$block_author"


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-registry/issues/291 and https://github.com/radicle-dev/radicle-registry/issues/341.

The chain spec is now picked during the compilation with en environment variable. The resulting node binary has no way to change it.

The CI is building the `ffnet` node, the development scripts `dev` and the local devnet docs give instructions to use a `local-devnet`.