### PR TITLE
Fix CLI reporting terminated streams on errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,9 +1915,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9ae166c4d1f702d297cd76d4b55758ace80272ffc6dbb139fdc1bf810de40b"
+version = "14.1.0"
+source = "git+https://github.com/paritytech/jsonrpc?tag=v14.1.0#06375c3d31971f177bbf1a11c5d0216b03b106e7"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -1933,9 +1932,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3b688648f1ef5d5072229e2d672ecb92cbff7d1c79bcf3fd5898f3f3df0970"
+version = "14.1.0"
+source = "git+https://github.com/paritytech/jsonrpc?tag=v14.1.0#06375c3d31971f177bbf1a11c5d0216b03b106e7"
 dependencies = [
  "futures 0.1.29",
  "log 0.4.8",
@@ -1946,9 +1944,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080dc110be17701097df238fad3c816d4a478a1899dfbcf8ec8957dd40ec7304"
+version = "14.1.0"
+source = "git+https://github.com/paritytech/jsonrpc?tag=v14.1.0#06375c3d31971f177bbf1a11c5d0216b03b106e7"
 dependencies = [
  "jsonrpc-client-transports",
 ]
@@ -1982,9 +1979,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b31c9b90731276fdd24d896f31bb10aecf2e5151733364ae81123186643d939"
+version = "14.1.0"
+source = "git+https://github.com/paritytech/jsonrpc?tag=v14.1.0#06375c3d31971f177bbf1a11c5d0216b03b106e7"
 dependencies = [
  "jsonrpc-core",
  "log 0.4.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,10 @@ members = [
   "runtime",
   "test-utils"
   ]
+
+# TODO remove when Substrate upgrades jsonrpc-core-client to 14.1.0
+# https://github.com/paritytech/substrate/issues/5623
+[patch.crates-io]
+jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc", tag = "v14.1.0" }
+jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc", tag = "v14.1.0" }
+jsonrpc-core-client = { git = "https://github.com/paritytech/jsonrpc", tag = "v14.1.0" }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -127,24 +127,24 @@ pub trait CommandT {
 /// Implements [From] for client errors and [account_storage] errors.
 #[derive(Debug, ThisError)]
 pub enum CommandError {
-    #[error("Client error: {0}")]
+    #[error("client error")]
     ClientError(#[from] Error),
 
-    #[error("Transaction {tx_hash} failed in block {block_hash}")]
+    #[error("transaction {tx_hash} failed in block {block_hash}")]
     FailedTransaction {
         tx_hash: TxHash,
         block_hash: BlockHash,
     },
 
-    #[error("Cannot find org {org_id}")]
+    #[error("cannot find org {org_id}")]
     OrgNotFound { org_id: OrgId },
 
-    #[error("Cannot find project {project_name}.{org_id}")]
+    #[error("cannot find project {project_name}.{org_id}")]
     ProjectNotFound {
         project_name: ProjectName,
         org_id: OrgId,
     },
 
-    #[error("{0}")]
+    #[error(transparent)]
     AccountStorageError(#[from] account_storage::Error),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,7 @@
 //! The executable entry point for the Radicle Registry CLI.
 
 use radicle_registry_cli::CommandLine;
+use std::error::Error;
 use structopt::StructOpt;
 
 #[async_std::main]
@@ -27,8 +28,16 @@ async fn main() {
     match result {
         Ok(_) => std::process::exit(0),
         Err(error) => {
-            eprintln!("ERROR: {}", error);
+            print_error(&error);
             std::process::exit(1);
         }
+    }
+}
+
+fn print_error(mut error: &dyn Error) {
+    eprintln!("Error: {}", error);
+    while let Some(source) = error.source() {
+        error = source;
+        eprintln!("  Caused by: {}", error);
     }
 }

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -205,7 +205,7 @@ async fn invalid_transaction() {
 
     let response = client.submit_transaction(transfer_tx).await;
     match response {
-        Err(Error::Other(_)) => (),
+        Err(Error::Rpc(_)) => (),
         Err(error) => panic!("Unexpected error {:?}", error),
         Ok(_) => panic!("Transaction was accepted unexpectedly"),
     }
@@ -226,7 +226,7 @@ async fn insufficient_fee() {
         .await;
 
     match response {
-        Err(Error::Other(_)) => (),
+        Err(Error::Rpc(_)) => (),
         Err(error) => panic!("Unexpected error {:?}", error),
         Ok(_) => panic!("Transaction was accepted unexpectedly"),
     }
@@ -249,7 +249,7 @@ async fn insufficient_funds() {
         .await;
 
     match response {
-        Err(Error::Other(_)) => (),
+        Err(Error::Rpc(_)) => (),
         Err(error) => panic!("Unexpected error {:?}", error),
         Ok(_) => panic!("Transaction was accepted unexpectedly"),
     }


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-registry/issues/348.
It does 2 things to improve reporting errors to the users:
1. Patches jsonrpc with the newest version from master, which handles errors correctly (temporary fix until Substrate officially releases it and upgrades Substrate)
2. Prints CLI errors recursively