### PR TITLE
Document how to build from source

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@ The code is bootstrapped with the [`substrate-node-template`][node-template].
 
 <!-- toc -->
 
-- [Build requirements](#build-requirements)
+- [Prerequisites](#prerequisites)
 - [Running development node](#running-development-node)
 - [Packages](#packages)
 - [Running checks and tests](#running-checks-and-tests)
@@ -21,14 +21,10 @@ The code is bootstrapped with the [`substrate-node-template`][node-template].
 
 <!-- tocstop -->
 
-Build requirements
-------------------
+Prerequisites
+-------------
 
-1. Get [`rustup`][rustup-install]
-2. Run `./scripts/rustup-setup` to install all required `rustup` components and
-   targets.
-
-[rustup-install]: https://github.com/rust-lang/rustup.rs#installation
+Follow the [README's Prerequisites guide](README.md#prerequisites).
 
 
 Running development node

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@ Radicle Registry
 
 Experimental Radicle Registry implementation with Substrate.
 
-See [`DEVELOPING.md`][dev-manual] for developer information.
+Click [here](https://radicle.run/docs/getting-started) to learn how to get
+started participating in the Radicle Registry Network.
+
+See [`DEVELOPING.md`](./DEVELOPING.md) for developer information.
 
 <!-- toc -->
 
+- [Prerequisites](#prerequisites)
+- [Build from source](#build-from-source)
 - [Getting the Node](#getting-the-node)
 - [Running the node](#running-the-node)
 - [Using the Client](#using-the-client)
@@ -18,6 +23,51 @@ See [`DEVELOPING.md`][dev-manual] for developer information.
 - [License](#license)
 
 <!-- tocstop -->
+
+Prerequisites
+---------------
+
+ⓘ Follow this guide to get started [developing](./DEVELOPING.md)
+   or to [build from source](#build-from-source).
+
+1. [Install Rust](https://www.rust-lang.org/tools/install)
+
+   It will run `rustup`, The Rust toolchain installer, which installs
+   `rustc`, `cargo`, `rustup`, amongst other standard tools that compose
+   the default Rust toolchain.
+
+2. Run `rustc --version` in a new shell.
+
+   To verify that the installion is sound.
+
+3. Run `./scripts/rustup-setup`
+
+   To install all `rustup` components and targets required by the
+   Radicle Registry.
+
+
+Build from source
+-----------------
+
+⚠ Make sure you have followed the [prerequisites](#prerequisites) guide
+  before proceeding.
+
+We currently only provide prebuilt binaries for `x86_64` linux targets in
+the [Radicle Registry Releases][releases-page] page.
+
+To build the Radicle Registry binaries to run on other targers, run:
+
+``` bash
+./scripts/build-release
+```
+
+The resulting binaries can be found at:
+
+* `./target/release/radicle-registry-cli`
+* `./target/release/radicle-registry-node`
+
+[releases-page]: https://github.com/radicle-dev/radicle-registry/releases
+
 
 Getting the Node
 ----------------
@@ -148,10 +198,6 @@ Using the CLI
 
 We provide a CLI to talk read and update the ledger in the `cli` directory. To
 learn more run `cargo run -p radicle-registry-cli -- --help`.
-
-
-[dev-manual]: ./DEVELOPING.md
-[rustup-install]: https://github.com/rust-lang/rustup.rs#installation
 
 
 License

--- a/ci/run
+++ b/ci/run
@@ -55,8 +55,8 @@ echo "--- cargo doc"
 RUSTDOCFLAGS="-D intra-doc-link-resolution-failure" \
   cargo doc --workspace --no-deps --document-private-items
 
-echo "--- scripts/build-release
-time ./scripts/build-release
+echo "--- scripts/build-release"
+./scripts/build-release
 
 echo "--- cargo test"
 echo "Starting radicle-registry-node"

--- a/ci/run
+++ b/ci/run
@@ -55,8 +55,8 @@ echo "--- cargo doc"
 RUSTDOCFLAGS="-D intra-doc-link-resolution-failure" \
   cargo doc --workspace --no-deps --document-private-items
 
-echo "--- cargo build"
-DEFAULT_CHAIN=ffnet cargo build --workspace --all-targets --release
+echo "--- scripts/build-release
+time ./scripts/build-release
 
 echo "--- cargo test"
 echo "Starting radicle-registry-node"

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Build the CLI and node binaries for release. The resulting binaries can be found at:
+# * `./target/release/radicle-registry-cli`
+# * `./target/release/radicle-registry-node`
+
+DEFAULT_CHAIN=ffnet cargo build --workspace --all-targets --release


### PR DESCRIPTION
Closes #318 

It wasn't straight forward to figure where to place this new info.
I decided to have it in the README since it's more user-friendly and satisfies
the developer and participant use cases fairly.

Ran the instructions in a vanilla macOS.

I find the README and DEVELOPING files rather convoluted, I will give it some thought on how to improve them.