### PR TITLE
cli: Refactor lookup_account

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -83,11 +83,9 @@ lazy_static! {
 }
 
 fn lookup_account(name: &str) -> Result<ed25519::Pair, String> {
-    let accounts = account_storage::list().map_err(|e| format!("{}", e))?;
-    match accounts.get(&name.to_string()) {
-        Some(account) => Ok(ed25519::Pair::from_seed(&account.seed)),
-        None => Err(format!("Could not find local account named '{}'", name)),
-    }
+    account_storage::get(name)
+        .map(|account| ed25519::Pair::from_seed(&account.seed))
+        .map_err(|e| format!("{}", e))
 }
 
 /// The supported [CommandLine] commands.


### PR DESCRIPTION
This was a thorn in my side, where I wanted to have the logic getting a specific account encapsulated within `account_storage` but my Rust had not figure how to overcome the compiler.

Thanks for the tip, @geigerzaehler :smile: 

