### PR TITLE
Make node the entrypoint for docker image

### DIFF
--- a/ci/node-image/Dockerfile
+++ b/ci/node-image/Dockerfile
@@ -1,3 +1,5 @@
 FROM debian:buster-slim
 
+ENTRYPOINT ["radicle-registry-node"]
 ADD ./radicle-registry-node /usr/local/bin/
+


### PR DESCRIPTION
To simplify the usage of the docker images we make the node the entrypoint.

Before:

    docker run gcr.io/opensourcecoin/radicle-registry/node:<commit-sha> radicle-registry-node

After:

    docker run gcr.io/opensourcecoin/radicle-registry/node:<commit-sha>