### PR TITLE
CLI: improve error propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
 
 [[package]]
+name = "derive-try-from-primitive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302ccf094df1151173bb6f5a2282fcd2f45accd5eae1bdf82dcbfefbc501ad5c"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3694,7 @@ dependencies = [
 name = "radicle-registry-core"
 version = "0.0.0"
 dependencies = [
+ "derive-try-from-primitive",
  "parity-scale-codec",
  "rand 0.7.3",
  "sp-core",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ std = [
 ]
 
 [dependencies]
+derive-try-from-primitive = "1.0.0"
 rand = { version = "0.7.2", optional = true }
 
 [dependencies.parity-scale-codec]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -15,7 +15,10 @@
 
 use crate::DispatchError;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+use derive_try_from_primitive::TryFromPrimitive;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
 /// Errors describing failed Registry transactions.
 pub enum RegistryError {
     InexistentCheckpointId = 0,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -41,7 +41,7 @@ impl From<RegistryError> for &'static str {
             RegistryError::InexistentCheckpointId => "The provided checkpoint does not exist",
             RegistryError::InexistentOrg => "The provided org does not exist",
             RegistryError::InexistentUser => "The provided user does not exist",
-            RegistryError::DuplicateOrgId => "An org with a similar ID already exists.",
+            RegistryError::DuplicateOrgId => "An org with the same ID already exists.",
             RegistryError::DuplicateProjectId => "A project with a similar ID already exists.",
             RegistryError::DuplicateUserId => "A user with the same ID already exists.",
             RegistryError::InexistentProjectId => "Project does not exist",
@@ -67,14 +67,15 @@ impl From<RegistryError> for &'static str {
     }
 }
 
+// The index with which the registry runtime module is declared
+// in the Radicle Registry runtime - see the `construct_runtime`
+// declaration in the `runtime` crate.
+const REGISTRY_ERROR_INDEX: u8 = 7;
+
 impl From<RegistryError> for DispatchError {
     fn from(error: RegistryError) -> Self {
-        // This is the index with which the registry runtime module is declared
-        // in the Radicle Registry runtime - see the `construct_runtime`
-        // declaration in the `runtime` crate.
-        let registry_index = 7;
         DispatchError::Module {
-            index: registry_index,
+            index: REGISTRY_ERROR_INDEX,
             error: error as u8,
             message: None,
         }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -67,6 +67,14 @@ impl From<RegistryError> for &'static str {
     }
 }
 
+#[cfg(feature = "std")]
+impl core::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        let s: &str = self.clone().into();
+        write!(f, "{}", s)
+    }
+}
+
 // The index with which the registry runtime module is declared
 // in the Radicle Registry runtime - see the `construct_runtime`
 // declaration in the `runtime` crate.


### PR DESCRIPTION
Closes #349, Starts addressing #294.

Note that the scope of this PR is specific to the first ffnet release, not trying to fix #294 altogether and in one go.
