### PR TITLE
cli: Mutually support address and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Upcoming
 * Polkadot telemetry was removed
 
 ### Addition
+* cli: Mutually support local account names where only SS58 address were
+  supported as params.
 * Add `user list` and `user show` CLI commands
 * Add `MINIMUM_FEE` to the registry client
 * The client emulator now authors blocks when a transaction is submitted.

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -47,7 +47,7 @@ impl CommandT for Command {
 /// Show the balance of an account
 #[derive(StructOpt, Clone)]
 pub struct ShowBalance {
-    /// SS58 address
+    /// SS58 address or name of a local account.
     #[structopt(
         value_name = "account",
         parse(try_from_str = parse_account_id),
@@ -109,7 +109,8 @@ pub struct Transfer {
     // The amount to transfer.
     amount: Balance,
 
-    /// Recipient Account in SS58 address format.
+    /// The recipient account.
+    /// SS58 address or name of a local account.
     #[structopt(parse(try_from_str = parse_account_id))]
     recipient: AccountId,
 

--- a/cli/src/command/org.rs
+++ b/cli/src/command/org.rs
@@ -170,7 +170,8 @@ pub struct Transfer {
     // The amount to transfer from the org to the recipient.
     amount: Balance,
 
-    /// Recipient Account in SS58 address format
+    /// The recipient account.
+    /// SS58 address or name of a local account.
     #[structopt(parse(try_from_str = parse_account_id))]
     recipient: AccountId,
 


### PR DESCRIPTION
Closes #376 (+ it does that for all params parsing ss58 addresses)

All CLI params currently receiving an SS58 address now also support a
local account, in a polymorphic fashion by falling back.