### PR TITLE
Improve cli show commands outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "directories",
  "futures 0.3.4",
  "hex",
+ "itertools",
  "lazy_static",
  "pretty_env_logger",
  "radicle-registry-client",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ derive_more = "0.99"
 directories = "2.0.2"
 futures = "0.3"
 hex = "0.4.0"
+itertools = "0.8.2"
 lazy_static = "1.4.0"
 pretty_env_logger = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -16,6 +16,7 @@
 //! Define the commands supported by the CLI.
 
 use crate::{lookup_account, CommandError, CommandT, NetworkOptions, TxOptions};
+use itertools::Itertools;
 use radicle_registry_client::*;
 
 use sp_core::crypto::Ss58Codec;

--- a/cli/src/command/org.rs
+++ b/cli/src/command/org.rs
@@ -86,9 +86,9 @@ impl CommandT for Show {
             })?;
 
         println!("id: {}", org.id);
-        println!("account_id: {}", org.account_id);
-        println!("members: {:?}", org.members);
-        println!("projects: {:?}", org.projects);
+        println!("account id: {}", org.account_id);
+        println!("member ids: [{}]", org.members.iter().format(", "));
+        println!("projects: [{}]", org.projects.iter().format(", "));
         Ok(())
     }
 }

--- a/cli/src/command/user.rs
+++ b/cli/src/command/user.rs
@@ -131,8 +131,8 @@ impl CommandT for Show {
                 })?;
 
         println!("id: {}", user.id);
-        println!("account_id: {}", user.account_id);
-        println!("projects: {:?}", user.projects);
+        println!("account id: {}", user.account_id);
+        println!("projects: [{}]", user.projects.iter().format(", "));
         Ok(())
     }
 }


### PR DESCRIPTION
The outputs are now more user friendly. The most important part is that the the org member ids were displayed as hexes and the first 8 characters of the SS58, now it's just the full SS58.