### PR TITLE
cli: Show org balance on 'org show'

### DIFF
--- a/cli/src/command/org.rs
+++ b/cli/src/command/org.rs
@@ -84,9 +84,11 @@ impl CommandT for Show {
             .ok_or(CommandError::OrgNotFound {
                 org_id: self.org_id.clone(),
             })?;
+        let balance = client.free_balance(&org.account_id).await?;
 
         println!("id: {}", org.id);
         println!("account id: {}", org.account_id);
+        println!("balance: {} μRAD", balance);
         println!("member ids: [{}]", org.members.iter().format(", "));
         println!("projects: [{}]", org.projects.iter().format(", "));
         Ok(())


### PR DESCRIPTION
> An open question: would it make sense to show the amount held by the org in `radicle-registry-cli org show <org_name>`? Now this information is hidden deep in a separate command `radicle-registry-cli account balance <org_id>` by @CodeSandwich 