### PR TITLE
Cli: improve account commands and docs

### DIFF
--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -21,8 +21,8 @@ use crate::account_storage;
 /// Account related commands
 #[derive(StructOpt, Clone)]
 pub enum Command {
-    /// Show the balance of an account.
-    Balance(ShowBalance),
+    /// Show information for a given account.
+    Show(Show),
     /// Generate a local account and store it on disk.
     /// Fail if there is already an account with the given `name`
     Generate(Generate),
@@ -36,7 +36,7 @@ pub enum Command {
 impl CommandT for Command {
     async fn run(self) -> Result<(), CommandError> {
         match self {
-            Command::Balance(cmd) => cmd.run().await,
+            Command::Show(cmd) => cmd.run().await,
             Command::Generate(cmd) => cmd.run().await,
             Command::List(cmd) => cmd.run().await,
             Command::Transfer(cmd) => cmd.run().await,
@@ -44,9 +44,8 @@ impl CommandT for Command {
     }
 }
 
-/// Show the balance of an account
 #[derive(StructOpt, Clone)]
-pub struct ShowBalance {
+pub struct Show {
     /// SS58 address or name of a local account.
     #[structopt(
         value_name = "account",
@@ -59,11 +58,12 @@ pub struct ShowBalance {
 }
 
 #[async_trait::async_trait]
-impl CommandT for ShowBalance {
+impl CommandT for Show {
     async fn run(self) -> Result<(), CommandError> {
         let client = self.network_options.client().await?;
         let balance = client.free_balance(&self.account_id).await?;
-        println!("{} μRAD", balance);
+        println!("ss58 address: {}", self.account_id.to_ss58check());
+        println!("balance: {} μRAD", balance);
         Ok(())
     }
 }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -21,7 +21,7 @@ use crate::account_storage;
 /// Account related commands
 #[derive(StructOpt, Clone)]
 pub enum Command {
-    /// Show information for a given account.
+    /// Show information for a local, user's, or org's account
     Show(Show),
     /// Generate a local account and store it on disk.
     /// Fail if there is already an account with the given `name`
@@ -46,7 +46,7 @@ impl CommandT for Command {
 
 #[derive(StructOpt, Clone)]
 pub struct Show {
-    /// SS58 address or name of a local account.
+    /// The account's SS58 address or the name of a local account.
     #[structopt(
         value_name = "account",
         parse(try_from_str = parse_account_id),

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -48,7 +48,7 @@ impl CommandT for Command {
 pub struct Show {
     /// The account's SS58 address or the name of a local account.
     #[structopt(
-        value_name = "account",
+        value_name = "address_or_name",
         parse(try_from_str = parse_account_id),
     )]
     account_id: AccountId,


### PR DESCRIPTION
Context: output from the last internal test run and other small improvements found while going through it.

1. `account balance` -> `account show`

    To be consistent with the other sub commands 'user show', 'project
    show', 'org show'. Also, print the address, which won't be redundant
    when the passed param is a local account name.

    Suggested by @CodeSandwich after the last internal testing run.

2. Explain account show being for local/user/org accounts

    That might not be clear, so better be explicit to users.

3. cli: Change 'account show' arg value_name

    Not doing the same to the account arg of `account transfer` and `org
    transfer` because for those understanding the param to be `recipient` is
    more useful.

