### PR TITLE
Make Org members Vec<Id> instead of Vec<AccountId>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* Tx author needs to have an associated registered user to operate on Orgs
+* `Org::members` is now `Vec<Id>`
 * cli: Rename the key-pair storage file from 'accounts.json' to 'key-pairs.json'
 * cli: Move key-pair related commands under the new `key-pair` command group
 * client: `TransactionApplied` result is now `Result<(), TransactionError>`

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -99,6 +99,12 @@ pub enum RegistryError {
         error("the account is already associated with a user")
     )]
     UserAccountAssociated,
+
+    #[cfg_attr(
+        feature = "std",
+        error("the tx author needs to have an associated user")
+    )]
+    AuthorHasNoAssociatedUser,
 }
 
 // The index with which the registry runtime module is declared

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Org {
     pub account_id: AccountId,
 
     /// See [state::Org::members]
-    pub members: Vec<AccountId>,
+    pub members: Vec<Id>,
 
     /// See [state::Org::projects]
     pub projects: Vec<ProjectName>,

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -27,13 +27,16 @@ use parity_scale_codec::{Decode, Encode};
 ///
 /// If successful, a new [crate::state::Org] with the given properties is added to the state.
 ///
-/// [crate::state::Org::members] is initialized with the transaction author as the only member.
+/// [crate::state::Org::members] is initialized with the user id associated with the author
+/// as the only member.
 ///
 /// [crate::state::Org::account_id] is generated randomly.
 ///
 /// # State-dependent validations
 ///
 /// An Org with the same ID must not yet exist.
+///
+/// A user associated with the author must exist.
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterOrg {
@@ -48,8 +51,8 @@ pub struct RegisterOrg {
 ///
 /// # State-dependent validations
 ///
-/// The targeted org must exist and have no projects and the
-/// the transaction origin must be its only member.
+/// The targeted org must exist, have no projects, and a user
+/// associated with the author must exist and be its only member.
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct UnregisterOrg {
@@ -66,7 +69,7 @@ pub struct UnregisterOrg {
 ///
 /// # State-dependent validations
 ///
-/// An Org with the same ID must not yet exist.
+/// A user with the same ID must not yet exist.
 ///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct RegisterUser {
@@ -101,7 +104,9 @@ pub struct UnregisterUser {
 ///
 /// The involved org must exit.
 ///
-/// The author must be a member of the involved org.
+/// A user associated with the author must exist.
+///
+/// The user associated with the author must be a member of the involved org.
 ///
 /// A checkpoint with the given ID must exist.
 ///
@@ -149,7 +154,9 @@ pub struct CreateCheckpoint {
 ///
 /// The checkpoint `new_checkpoint_id` must exist.
 ///
-/// The transaction author must be part of the [crate::state::Org::members] of the given project.
+/// A user associated with the transaction author must exist and
+/// be a member of the Org of the given project.
+///
 #[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
 pub struct SetCheckpoint {
     pub project_name: ProjectName,
@@ -170,7 +177,8 @@ pub struct SetCheckpoint {
 ///
 /// # State-dependent validations
 ///
-/// The author must be a member of [crate::state::Org::members].
+/// A user associated with the transaction author must exist and
+/// be a member of the Org of the given project.
 ///
 /// The org account must have a balance of at least `value`.
 ///

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use sp_runtime::traits::Hash;
 
-use crate::{AccountId, Balance, Bytes128, CheckpointId, Hashing, ProjectName, H256};
+use crate::{AccountId, Balance, Bytes128, CheckpointId, Hashing, Id, ProjectName, H256};
 
 /// A checkpoint defines an immutable state of a project’s off-chain data via a hash.
 ///
@@ -134,9 +134,10 @@ pub struct Org {
     /// Set of members of the org. Members are allowed to manage
     /// the org, its projects, and transfer funds.
     ///
-    /// It is initialized with the author of the [crate::message::RegisterOrg]
-    /// transaction. It cannot be changed at the moment.
-    pub members: Vec<AccountId>,
+    /// It is initialized with the user id associated with the author
+    /// of the [crate::message::RegisterOrg] transaction.
+    /// It cannot be changed at the moment.
+    pub members: Vec<Id>,
 
     /// Set of all projects owned by the org. Members are allowed to register
     /// a project by sending a [crate::message::RegisterProject] transaction.

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -42,6 +42,9 @@ pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
             let run_cmd = args.run_cmd();
             run_cmd.init(&version)?;
             run_cmd.update_config(&mut config, spec_factory, &version)?;
+            config.execution_strategies.block_construction =
+                sc_client::ExecutionStrategy::NativeElseWasm;
+
             if unsafe_rpc_external {
                 // Allow all hosts to connect
                 config.rpc_cors = None;

--- a/runtime-tests/tests/project_registration.rs
+++ b/runtime-tests/tests/project_registration.rs
@@ -24,12 +24,12 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn register_project() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let project_hash = H256::random();
     let checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash,
             previous_checkpoint_id: None,
@@ -40,7 +40,7 @@ async fn register_project() {
     .unwrap();
 
     let register_org = random_register_org_message();
-    submit_ok(&client, &alice, register_org.clone()).await;
+    submit_ok(&client, &author, register_org.clone()).await;
 
     // The org needs funds to submit transactions.
     let org = client
@@ -49,11 +49,11 @@ async fn register_project() {
         .unwrap()
         .unwrap();
     let initial_balance = 1000;
-    transfer(&client, &alice, org.account_id, initial_balance).await;
+    transfer(&client, &author, org.account_id, initial_balance).await;
 
     let random_fee = random_balance();
     let message = random_register_project_message(register_org.org_id.clone(), checkpoint_id);
-    let tx_applied = submit_ok_with_fee(&client, &alice, message.clone(), random_fee).await;
+    let tx_applied = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
 
     let project = client
         .get_project(message.clone().project_name, message.clone().org_id)
@@ -107,12 +107,12 @@ async fn register_project() {
 #[async_std::test]
 async fn register_project_with_inexistent_org() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let project_hash = H256::random();
     let checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash,
             previous_checkpoint_id: None,
@@ -124,7 +124,7 @@ async fn register_project_with_inexistent_org() {
 
     let inexistent_org_id = random_id();
     let message = random_register_project_message(inexistent_org_id, checkpoint_id);
-    let tx_applied = submit_ok(&client, &alice, message.clone()).await;
+    let tx_applied = submit_ok(&client, &author, message.clone()).await;
 
     assert_eq!(tx_applied.result, Err(RegistryError::InexistentOrg.into()));
 }
@@ -132,11 +132,11 @@ async fn register_project_with_inexistent_org() {
 #[async_std::test]
 async fn register_project_with_duplicate_id() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash: H256::random(),
             previous_checkpoint_id: None,
@@ -150,19 +150,19 @@ async fn register_project_with_duplicate_id() {
     let register_org = message::RegisterOrg {
         org_id: org_id.clone(),
     };
-    submit_ok(&client, &alice, register_org.clone()).await;
+    submit_ok(&client, &author, register_org.clone()).await;
 
     // The org needs funds to submit transactions.
     let org = client.get_org(org_id.clone()).await.unwrap().unwrap();
-    transfer(&client, &alice, org.account_id, 1000).await;
+    transfer(&client, &author, org.account_id, 1000).await;
 
     let message = random_register_project_message(org_id.clone(), checkpoint_id);
-    submit_ok(&client, &alice, message.clone()).await;
+    submit_ok(&client, &author, message.clone()).await;
 
     // Duplicate submission with a different metadata.
     let registration_2 = submit_ok(
         &client,
-        &alice,
+        &author,
         message::RegisterProject {
             metadata: Bytes128::random(),
             ..message.clone()
@@ -196,7 +196,7 @@ async fn register_project_with_duplicate_id() {
 #[async_std::test]
 async fn register_project_with_bad_checkpoint() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let checkpoint_id = H256::random();
 
@@ -205,13 +205,13 @@ async fn register_project_with_bad_checkpoint() {
     let register_org = message::RegisterOrg {
         org_id: org_id.clone(),
     };
-    submit_ok(&client, &alice, register_org.clone()).await;
+    submit_ok(&client, &author, register_org.clone()).await;
 
     // The org needs funds to submit transactions.
     let org = client.get_org(org_id.clone()).await.unwrap().unwrap();
-    transfer(&client, &alice, org.account_id, 1000).await;
+    transfer(&client, &author, org.account_id, 1000).await;
 
-    let tx_applied = submit_ok(&client, &alice, register_project.clone()).await;
+    let tx_applied = submit_ok(&client, &author, register_project.clone()).await;
 
     assert_eq!(
         tx_applied.result,
@@ -228,17 +228,15 @@ async fn register_project_with_bad_checkpoint() {
 #[async_std::test]
 async fn register_project_with_bad_actor() {
     let client = Client::new_emulator();
-    let god_actor = key_pair_from_string("Alice");
-    let bad_actor = key_pair_from_string("BadActor");
-    // The bad actor needs funds to submit transactions.
-    transfer(&client, &god_actor, bad_actor.public(), 1000).await;
+    let (good_actor, _) = key_pair_with_associated_user(&client).await;
+    let (bad_actor, _) = key_pair_with_associated_user(&client).await;
 
     // The good actor creates an org, of which becomes its single member.
     let org_id = random_id();
     let register_org = message::RegisterOrg {
         org_id: org_id.clone(),
     };
-    submit_ok(&client, &god_actor, register_org.clone()).await;
+    submit_ok(&client, &good_actor, register_org.clone()).await;
 
     // The bad actor attempts to register a project within that org.
     let initial_balance = client.free_balance(&bad_actor.public()).await.unwrap();

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::registry::store;
+use crate::registry::{org_has_member_with_account, store};
 use crate::{AccountId, Call, DispatchError, Runtime};
 use radicle_registry_core::*;
 
@@ -89,12 +89,12 @@ fn payer_account(author: AccountId, call: &Call) -> AccountId {
 }
 
 /// Find which account should pay for an org-related call.
-/// When `author` is a member of the org identified by `org_id`,
-/// return that org's account, otherwise the author's.
+/// When the User associated with `author` is a member of the org
+/// identified by `org_id`, return that org's account, otherwise the author's.
 fn org_payer_account(author: AccountId, org_id: &Id) -> AccountId {
     match store::Orgs::get(org_id) {
         Some(org) => {
-            if org.members.contains(&author) {
+            if org_has_member_with_account(&org, author) {
                 org.account_id
             } else {
                 author

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -150,12 +150,8 @@ decl_module! {
         pub fn register_project(origin, message: message::RegisterProject) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
-            let org = match store::Orgs::get(message.org_id.clone()) {
-                None => return Err(RegistryError::InexistentOrg.into()),
-                Some(o) => o,
-            };
-
-            if !org.members.contains(&sender) {
+            let org = store::Orgs::get(message.org_id.clone()).ok_or(RegistryError::InexistentOrg)?;
+            if !org_has_member_with_account(&org, sender) {
                 return Err(RegistryError::InsufficientSenderPermissions.into());
             }
 
@@ -186,10 +182,11 @@ decl_module! {
         pub fn register_org(origin, message: message::RegisterOrg) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
-            match store::Orgs::get(message.org_id.clone()) {
-                None => {},
-                Some(_) => return Err(RegistryError::DuplicateOrgId.into()),
+            if store::Orgs::get(message.org_id.clone()).is_some() {
+                return Err(RegistryError::DuplicateOrgId.into());
             }
+
+            let user = get_user_with_account(sender).ok_or(RegistryError::AuthorHasNoAssociatedUser)?;
 
             let random_account_id = AccountId::unchecked_from(
                 pallet_randomness_collective_flip::Module::<T>::random(
@@ -199,7 +196,7 @@ decl_module! {
 
             let new_org = state::Org {
                 account_id: random_account_id,
-                members: vec![sender],
+                members: vec![user.id],
                 projects: Vec::new(),
             };
             store::Orgs::insert(message.org_id.clone(), new_org);
@@ -210,7 +207,8 @@ decl_module! {
         #[weight = SimpleDispatchInfo::InsecureFreeNormal]
         pub fn unregister_org(origin, message: message::UnregisterOrg) -> DispatchResult {
             fn can_be_unregistered(org: state::Org, sender: AccountId) -> bool {
-                org.members == vec![sender] && org.projects.is_empty()
+                org.projects.is_empty() && get_user_with_account(sender)
+                    .map(|user| org.members == vec![user.id]).unwrap_or(false)
             }
 
             let sender = ensure_signed(origin)?;
@@ -238,13 +236,8 @@ decl_module! {
                 return Err(RegistryError::DuplicateUserId.into())
             }
 
-            // TODO(xla): This is a naive first version of the check to see if an account is
-            // already associated to a user. While fine for small dataset this needs to be reworked
-            // in the future.
-            for user in store::Users::iter() {
-                if sender == user.1.account_id {
-                    return Err(RegistryError::UserAccountAssociated.into())
-                }
+            if get_user_with_account(sender).is_some() {
+                return Err(RegistryError::UserAccountAssociated.into())
             }
 
             let new_user = state::User {
@@ -282,11 +275,10 @@ decl_module! {
         #[weight = SimpleDispatchInfo::InsecureFreeNormal]
         pub fn transfer_from_org(origin, message: message::TransferFromOrg) -> DispatchResult {
             let sender = ensure_signed(origin)?;
-            let org = match store::Orgs::get(message.org_id) {
-                None => return Err(RegistryError::InexistentOrg.into()),
-                Some(o) => o,
-            };
-            if org.members.contains(&sender) {
+            let org = store::Orgs::get(message.org_id)
+                .ok_or(RegistryError::InexistentOrg)?;
+
+            if org_has_member_with_account(&org, sender) {
                 <crate::Balances as Currency<_>>::transfer(
                     &org.account_id,
                     &message.recipient,
@@ -341,7 +333,7 @@ decl_module! {
             let opt_org = store::Orgs::get(message.org_id.clone());
             let new_project = match (opt_project, opt_org) {
                 (Some(prj), Some(org)) => {
-                    if !org.members.contains(&sender) {
+                    if !org_has_member_with_account(&org, sender) {
                         return Err(RegistryError::InsufficientSenderPermissions.into())
                     }
                     state::Project {
@@ -399,6 +391,26 @@ decl_module! {
 
     }
 }
+
+// TODO(xla): This is a naive first version of the check to see if an account is
+// already associated to a user. While fine for small dataset this needs to be reworked
+// in the future.
+pub fn get_user_with_account(account_id: AccountId) -> Option<User> {
+    store::Users::iter()
+        .find(|(_, user)| user.account_id == account_id)
+        .map(|(id, user)| User::new(id, user))
+}
+
+/// Check whether the user associated with the given account_id is a member of the given org.
+/// Return false if the account doesn't have an associated user or if said user is not a member
+/// of the org.
+pub fn org_has_member_with_account(org: &state::Org, account_id: AccountId) -> bool {
+    match get_user_with_account(account_id) {
+        Some(user) => org.members.contains(&user.id),
+        None => false,
+    }
+}
+
 decl_event!(
     pub enum Event {
         CheckpointCreated(CheckpointId),


### PR DESCRIPTION
Closes #397 #396 

We check that authors registering an org are
registered users, which was a missing validation step (#397). 

That also means that to authorize actions on orgs, we now need to first lookup the user
associated with the tx author. 

When it comes to testing, now most tests need to have the tx author registering itself as a user.


:warning: The changes of this PR breaks the ffnet. Do NOT merge it to master. We have to think of a way to make these changes available to the upstream without affecting the chain network users.