### PR TITLE
scripts: Pass args at the end of run-dev-node

### DIFF
--- a/scripts/run-dev-node
+++ b/scripts/run-dev-node
@@ -5,4 +5,4 @@ set -euo pipefail
 # Adress for the seed string //Mine
 block_author=5HYpUCg4KKiwpih63PUHmGeNrK2XeTxKR83yNKbZeTsvSKNq
 radicle_registry_node=./target/release/radicle-registry-node
-exec $radicle_registry_node "$@" --chain dev --mine "$block_author"
+exec $radicle_registry_node --chain dev --mine "$block_author" "$@"


### PR DESCRIPTION
I needed to run `./run-dev-node purge-chain`, which didn't work given where the args are passed into the exec command. This change fixes it.