### PR TITLE
cli: Move from 'local account' to 'key-pair'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* cli: Rename the key-pair storage file from 'accounts.json' to 'key-pairs.json'
+* cli: Move key-pair related commands under the new `key-pair` command group
 * client: `TransactionApplied` result is now `Result<(), TransactionError>`
   for all messages.
 * cli: Drop `_TX_` from the environment options

--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ use radicle-registry-client::{ed25519, CryptoPair};
 let alice = ed25519::Pair::from_string("//Alice", None);
 ```
 
-To obtain the [`SS58`][ss58-docs] address for your local accounts, you can run:
+To obtain the [`SS58`][ss58-docs] address for your local key-pairs, you can run:
 
 ``` bash
-cargo run -p radicle-registry-cli -- account list
+cargo run -p radicle-registry-cli -- key-pair list
 ```
 
 The `radicle-registry-client::ed25519` module and the crypto traits are

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -16,18 +16,12 @@
 //! Define the commands supported by the CLI related to Accounts.
 
 use super::*;
-use crate::account_storage;
 
 /// Account related commands
 #[derive(StructOpt, Clone)]
 pub enum Command {
-    /// Show information for a local, user's, or org's account
+    /// Show account information.
     Show(Show),
-    /// Generate a local account and store it on disk.
-    /// Fail if there is already an account with the given `name`
-    Generate(Generate),
-    /// List all the local accounts.
-    List(List),
     /// Transfer funds from the author to a recipient account.
     Transfer(Transfer),
 }
@@ -37,8 +31,6 @@ impl CommandT for Command {
     async fn run(self) -> Result<(), CommandError> {
         match self {
             Command::Show(cmd) => cmd.run().await,
-            Command::Generate(cmd) => cmd.run().await,
-            Command::List(cmd) => cmd.run().await,
             Command::Transfer(cmd) => cmd.run().await,
         }
     }
@@ -46,7 +38,7 @@ impl CommandT for Command {
 
 #[derive(StructOpt, Clone)]
 pub struct Show {
-    /// The account's SS58 address or the name of a local account.
+    /// The account's SS58 address or the name of a local key pair.
     #[structopt(
         value_name = "address_or_name",
         parse(try_from_str = parse_account_id),
@@ -69,48 +61,12 @@ impl CommandT for Show {
 }
 
 #[derive(StructOpt, Clone)]
-pub struct Generate {
-    /// The name that uniquely identifies the account locally.
-    name: String,
-}
-
-#[async_trait::async_trait]
-impl CommandT for Generate {
-    async fn run(self) -> Result<(), CommandError> {
-        let (key_pair, seed) = ed25519::Pair::generate();
-        account_storage::add(self.name, account_storage::AccountData { seed })?;
-        println!("✓ Account generated successfully");
-        println!("ℹ SS58 address: {}", key_pair.public().to_ss58check());
-        Ok(())
-    }
-}
-#[derive(StructOpt, Clone)]
-pub struct List {}
-
-#[async_trait::async_trait]
-impl CommandT for List {
-    async fn run(self) -> Result<(), CommandError> {
-        let accounts = account_storage::list()?;
-
-        println!("Accounts ({})", accounts.len());
-        for (name, data) in accounts {
-            println!("Account '{}'", name);
-            println!(
-                "\tSS58 address: {}",
-                ed25519::Pair::from_seed(&data.seed).public().to_ss58check()
-            );
-        }
-        Ok(())
-    }
-}
-
-#[derive(StructOpt, Clone)]
 pub struct Transfer {
     // The amount to transfer.
     amount: Balance,
 
     /// The recipient account.
-    /// SS58 address or name of a local account.
+    /// SS58 address or name of a local key pair.
     #[structopt(parse(try_from_str = parse_account_id))]
     recipient: AccountId,
 

--- a/cli/src/command/key_pair.rs
+++ b/cli/src/command/key_pair.rs
@@ -1,0 +1,75 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Define the commands supported by the CLI related to key-pairs.
+
+use super::*;
+use crate::key_pair_storage;
+
+/// Key-pair related commands
+#[derive(StructOpt, Clone)]
+pub enum Command {
+    /// Generate a random key pair identified by `name` and
+    /// store it on disk. Fail if there is already a key pair
+    /// with the given `name`.
+    Generate(Generate),
+    /// List all the local key pairs.
+    List(List),
+}
+
+#[async_trait::async_trait]
+impl CommandT for Command {
+    async fn run(self) -> Result<(), CommandError> {
+        match self {
+            Command::Generate(cmd) => cmd.run().await,
+            Command::List(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Clone)]
+pub struct Generate {
+    /// The name that uniquely identifies the key pair locally.
+    name: String,
+}
+
+#[async_trait::async_trait]
+impl CommandT for Generate {
+    async fn run(self) -> Result<(), CommandError> {
+        let (key_pair, seed) = ed25519::Pair::generate();
+        key_pair_storage::add(self.name, key_pair_storage::KeyPairData { seed })?;
+        println!("✓ Key pair generated successfully");
+        println!("ⓘ SS58 address: {}", key_pair.public().to_ss58check());
+        Ok(())
+    }
+}
+#[derive(StructOpt, Clone)]
+pub struct List {}
+
+#[async_trait::async_trait]
+impl CommandT for List {
+    async fn run(self) -> Result<(), CommandError> {
+        let key_pairs = key_pair_storage::list()?;
+        println!("Key pairs ({})\n", key_pairs.len());
+        for (name, data) in key_pairs {
+            println!("  '{}'", name);
+            println!(
+                "  ss58 address: {}\n",
+                ed25519::Pair::from_seed(&data.seed).public().to_ss58check()
+            );
+        }
+        Ok(())
+    }
+}

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -15,7 +15,7 @@
 
 //! Define the commands supported by the CLI.
 
-use crate::{lookup_account, CommandError, CommandT, NetworkOptions, TxOptions};
+use crate::{lookup_key_pair, CommandError, CommandT, NetworkOptions, TxOptions};
 use itertools::Itertools;
 use radicle_registry_client::*;
 
@@ -23,6 +23,7 @@ use sp_core::crypto::Ss58Codec;
 use structopt::StructOpt;
 
 pub mod account;
+pub mod key_pair;
 pub mod org;
 pub mod other;
 pub mod project;
@@ -32,16 +33,16 @@ fn parse_account_id(data: &str) -> Result<AccountId, String> {
     Ss58Codec::from_ss58check(data)
         .map_err(|err| format!("{:?}", err))
         .or_else(|address_error| {
-            lookup_account(data)
-                .map(|account| account.public())
-                .map_err(|account_error| {
+            lookup_key_pair(data)
+                .map(|key_pair| key_pair.public())
+                .map_err(|key_pair_error| {
                     format!(
                         "
-    ! Could not parse an ss58 address nor find a local account with the given name.
+    ! Could not parse an ss58 address nor find a local key pair with the given name.
     ⓘ Error parsing SS58 address: {}
-    ⓘ Error looking up account: {}
+    ⓘ Error looking up key pair: {}
     ",
-                        address_error, account_error
+                        address_error, key_pair_error
                     )
                 })
         })

--- a/cli/src/command/org.rs
+++ b/cli/src/command/org.rs
@@ -173,7 +173,7 @@ pub struct Transfer {
     amount: Balance,
 
     /// The recipient account.
-    /// SS58 address or name of a local account.
+    /// SS58 address or name of a local key pair.
     #[structopt(parse(try_from_str = parse_account_id))]
     recipient: AccountId,
 

--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! Manages accounts stored in the filesystem,
+//! Manages key pairs stored in the filesystem,
 //! providing ways to store and retrieve them.
 
 use directories::BaseDirs;
@@ -26,37 +26,37 @@ use std::io::Error as IOError;
 use std::path::PathBuf;
 
 /// The data that is stored in the filesystem relative
-/// to an account. The account name is used as the key
-/// to this value, therefore not included here.
+/// to a key pair. The name of the key pair is used as
+/// the key to this value, therefore not included here.
 #[derive(Serialize, Deserialize, Clone)]
-pub struct AccountData {
+pub struct KeyPairData {
     pub seed: Seed,
 }
 
-/// The seed from which an account's key pair
-/// can be determiniscally generated.
+/// The seed from which a key pair
+/// can be deterministically generated.
 type Seed = [u8; 32];
 
 #[derive(Debug, ThisError)]
 pub enum Error {
-    /// An account with the given name already exists
-    #[error("An account with the given name already exists")]
+    /// A key pair with the given name already exists
+    #[error("A key pair with the given name already exists")]
     AlreadyExists(),
 
-    /// Failed to write to the accounts file
-    #[error("Failed to write to the accounts file: {0}")]
+    /// Failed to write to the key-pairs file
+    #[error("Failed to write to the key-pairs file: {0}")]
     FailedWrite(#[from] WritingError),
 
-    /// Failed to read the accounts file
-    #[error("Failed to read the accounts file: {0}")]
+    /// Failed to read the key-pairs file
+    #[error("Failed to read the key-pairs file: {0}")]
     FailedRead(#[from] ReadingError),
 
-    /// Could not find an account with the given name
-    #[error("Could not find an account with the given name")]
+    /// Could not find a key pair with the given name
+    #[error("Could not find a key pair with the given name")]
     NotFound(),
 }
 
-/// Possible errors when writing to the accounts file.
+/// Possible errors when writing to the key-pairs file.
 #[derive(Debug, ThisError)]
 pub enum WritingError {
     #[error(transparent)]
@@ -66,7 +66,7 @@ pub enum WritingError {
     Serialization(serde_json::Error),
 }
 
-/// Possible errors when reading the accounts file.
+/// Possible errors when reading the key-pairs file.
 #[derive(Debug, ThisError)]
 pub enum ReadingError {
     #[error(transparent)]
@@ -76,63 +76,76 @@ pub enum ReadingError {
     Deserialization(serde_json::Error),
 }
 
-/// Add an account to the storage.
+/// Add a key pair to the storage.
 ///
-/// Fails if an account with the given `name` already exists.
+/// Fails if a key pair with the given `name` already exists.
 /// It can also fail from IO and Serde Json errors.
-pub fn add(name: String, data: AccountData) -> Result<(), Error> {
-    let mut accounts = list()?;
-    if accounts.contains_key(&name) {
+pub fn add(name: String, data: KeyPairData) -> Result<(), Error> {
+    let mut key_pairs = list()?;
+    if key_pairs.contains_key(&name) {
         return Err(Error::AlreadyExists());
     }
 
-    accounts.insert(name, data);
-    update(accounts)
+    key_pairs.insert(name, data);
+    update(key_pairs)
 }
 
-/// List all the stored accounts.
+/// List all the stored key-pairs.
 ///
 /// It can fail from IO and Serde Json errors.
-pub fn list() -> Result<HashMap<String, AccountData>, Error> {
+pub fn list() -> Result<HashMap<String, KeyPairData>, Error> {
     let path_buf = get_or_create_path()?;
     let file = File::open(path_buf.as_path()).map_err(ReadingError::IO)?;
-    let accounts: HashMap<String, AccountData> =
+    let key_pairs: HashMap<String, KeyPairData> =
         serde_json::from_reader(&file).map_err(ReadingError::Deserialization)?;
-    Ok(accounts)
+    Ok(key_pairs)
 }
 
-/// Get an account by name.
+/// Get a key pair by name.
 ///
 /// It can fail from IO and Serde Json errors, or if no such
-/// account is found.
-pub fn get(name: &str) -> Result<AccountData, Error> {
+/// key pair is found.
+pub fn get(name: &str) -> Result<KeyPairData, Error> {
     list()?.get(name).map(Clone::clone).ok_or(Error::NotFound())
 }
 
-fn update(accounts: HashMap<String, AccountData>) -> Result<(), Error> {
+fn update(key_pairs: HashMap<String, KeyPairData>) -> Result<(), Error> {
     let path_buf = get_or_create_path()?;
-    let new_content = serde_json::to_string(&accounts).map_err(WritingError::Serialization)?;
+    let new_content = serde_json::to_string(&key_pairs).map_err(WritingError::Serialization)?;
     std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(WritingError::IO)?;
     Ok(())
 }
 
-const FILE: &str = "accounts.json";
+/// The file where the user key-pairs are stored.
+const FILE: &str = "key-pairs.json";
 
-// Get the path to the accounts file on disk.
-//
-// If the file does not yet exist, create it and initialize
-// it with an empty object so that it can be deserialized
-// as an empty HashMap<String, AccountData>.
+/// Get the path to the key-pairs file on disk.
+///
+/// If the file does not yet exist, create it and initialize
+/// it with an empty object so that it can be deserialized
+/// as an empty HashMap<String, KeyPairData>.
 fn get_or_create_path() -> Result<PathBuf, Error> {
-    let dir = dir()?;
-    let path_buf = dir.join(FILE);
-    let path = path_buf.as_path();
+    let path_buf = build_path(FILE)?;
 
+    let old_path = build_path("accounts.json")?;
+    if old_path.exists() {
+        println!("=> Migrating the key-pair storage to the latest version...");
+        std::fs::rename(old_path, &path_buf).map_err(WritingError::IO)?;
+        println!("✓ Done")
+    }
+
+    let path = path_buf.as_path();
     if !path.exists() {
         std::fs::write(path, b"{}").map_err(WritingError::IO)?;
     }
 
     Ok(path_buf)
+}
+
+fn build_path(filename: &str) -> Result<PathBuf, Error> {
+    let dir = dir()?;
+    let path = dir.join(filename);
+    Ok(path)
 }
 
 fn dir() -> Result<PathBuf, Error> {

--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -44,11 +44,11 @@ pub enum Error {
     AlreadyExists(),
 
     /// Failed to write to the key-pairs file
-    #[error("Failed to write to the key-pairs file: {0}")]
+    #[error("Failed to write to the key-pairs file")]
     FailedWrite(#[from] WritingError),
 
     /// Failed to read the key-pairs file
-    #[error("Failed to read the key-pairs file: {0}")]
+    #[error("Failed to read the key-pairs file")]
     FailedRead(#[from] ReadingError),
 
     /// Could not find a key pair with the given name


### PR DESCRIPTION
Closes #414 

- Disambiguate the terminology 'account' and 'local account' by now
calling local accounts key-pairs;
- Move key-pair related commands to a new command group 'key-pair'
- Update the README and the CHANGELOG
- Migrate the local accounts.json file to key-pairs.json

**Test required:**
 Pull this branch and run either of the `key-pair` sub-commands. Doing so will trigger a migration to rename the `accounts.json` file to `key-pairs.json`. I faced a permissions issue myself, where the `accounts.json` file permissions seem to have been changed somehow (recent system upgrade?).

**Note**: Docs companion PR: https://github.com/radicle-dev/registry.radicle.xyz/pull/37