### PR TITLE
cli: Check key-pair storage dir permissions

### DIFF
--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -65,11 +65,12 @@ pub enum Error {
 }
 
 fn io_error_message(action: &str) -> String {
-    let path_info = match build_path(FILE) {
-        Ok(x) => format!("{}", x.display()),
-        Err(e) => format!("{}", e),
-    };
-    format!("Failed to {} the key-pairs file: '{}'", action, path_info)
+    let path = build_path(FILE);
+    format!(
+        "Failed to {} the key-pairs file: '{}'",
+        action,
+        path.display()
+    )
 }
 
 /// Possible errors when writing to the key-pairs file.
@@ -141,9 +142,10 @@ const FILE: &str = "key-pairs.json";
 /// it with an empty object so that it can be deserialized
 /// as an empty HashMap<String, KeyPairData>.
 fn get_or_create_path() -> Result<PathBuf, Error> {
-    let path_buf = build_path(FILE)?;
+    let path_buf = build_path(FILE);
+    dir_ready(path_buf.parent().unwrap().to_path_buf())?;
 
-    let old_path = build_path("accounts.json")?;
+    let old_path = build_path("accounts.json");
     if old_path.exists() {
         println!("=> Migrating the key-pair storage to the latest version...");
         std::fs::rename(old_path, &path_buf).map_err(WritingError::IO)?;
@@ -158,24 +160,21 @@ fn get_or_create_path() -> Result<PathBuf, Error> {
     Ok(path_buf)
 }
 
-/// Build the path to the given file name under [dir_ready()].
-fn build_path(filename: &str) -> Result<PathBuf, Error> {
-    let dir = dir_ready()?;
-    let path = dir.join(filename);
-    Ok(path)
-}
-
-/// Ensure that the key-pair storage [dir()] is ready to be used.
+/// Ensure that the given directory path is ready to be used.
 /// Fails with
 ///   * [Error::CannotCreateDirectory] if the directory
 ///     does not exist and fails to be created.
-///    * [Error::CannotReadDirectory] if the directory
-///      does exist but can not be read.
-fn dir_ready() -> Result<PathBuf, Error> {
-    let dir = dir();
+///   * [Error::CannotReadDirectory] if the directory
+///     does exist but can not be read.
+fn dir_ready(dir: PathBuf) -> Result<PathBuf, Error> {
     std::fs::create_dir_all(&dir).map_err(|err| Error::CannotCreateDirectory(err, dir.clone()))?;
-    File::open(dir.as_path()).map_err(|err| Error::CannotReadDirectory(err, dir.clone()))?;
+    File::open(&dir).map_err(|err| Error::CannotReadDirectory(err, dir.clone()))?;
     Ok(dir)
+}
+
+/// Build the path to the given filename under [dir()].
+fn build_path(filename: &str) -> PathBuf {
+    dir().join(filename)
 }
 
 fn dir() -> PathBuf {


### PR DESCRIPTION
Closes: https://github.com/radicle-dev/radicle-registry/issues/420

### The problem

We have received [feedback from our user Alex Good](https://radicle.community/t/spinning-up-a-testnet-node-first-user-experience/196/6)  that got the following error when generating a key pair. 

```
Failed to read accounts file: Permission denied
```

This error, at this latest revision, would be: 

```
Failed to write the key-pairs file: "/home/<user>/.local/share/radicle-registry-cli/key-pairs.json" 
    Caused by: Permission denied (os error 13)
```

Although now we point out the directory we are working on, the error is incorrect when the real issue
is that the dir, ~/.local/share/radicle-registry-cli (on linux), is not readable or writable (can not be created). 


### Solution

In this commit, add `Error::InsufficientDirPermissions` to subset those specific cases that
have to do with the directory alone. 

A failed attempt to write the key-pairs.json file due to lacking permissions at the dir level will
still fail with the error reported above, which is fine since it shows the real failed intent and the whole path that must be writable.

The motivating issue, #420, focused on capturing the proper failing file when renaming `accounts.json` to `key-pairs.json`. However, I have never tested that being an issue, both when the dir and the `accounts.json` have no permissions at all.