### PR TITLE
cli: Use to_string_pretty on key-pairs.json

### DIFF
--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -128,7 +128,8 @@ pub fn get(name: &str) -> Result<KeyPairData, Error> {
 
 fn update(key_pairs: HashMap<String, KeyPairData>) -> Result<(), Error> {
     let path_buf = get_or_create_path()?;
-    let new_content = serde_json::to_string(&key_pairs).map_err(WritingError::Serialization)?;
+    let new_content =
+        serde_json::to_string_pretty(&key_pairs).map_err(WritingError::Serialization)?;
     std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(WritingError::IO)?;
     Ok(())
 }


### PR DESCRIPTION
Spontaneous mini change, prettifying the key-pairs.json content on write.

It will only take effect on the next key-pair generation. It's highly
optional so no need to force it like a migration step.

Since the `seed` field is an array, the pretty version if somewhat long vertically but I personally prefer that since it's much easier to parse visually.