### PR TITLE
Add best block size metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,6 +3719,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.11",
  "parking_lot 0.9.0",
+ "prometheus",
  "radicle-registry-runtime",
  "rand 0.7.3",
  "sc-basic-authorship",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,6 +26,8 @@ log = "0.4.8"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
 parking_lot = "0.9.0"
+# TODO remove in favor of substrate_prometheus_endpoint::prometheus after substrate upgrade
+prometheus = "0.8"
 rand = "0.7.3"
 serde = "1.0.104"
 serde_json = "1.0.48"


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-registry/issues/422 and https://github.com/radicle-dev/radicle-registry/issues/424. 

Unfortunately this PR is rather big, because some helpers had to be modified, they simply  didn't make sense anymore in the context of updating two gauges from a single worker task.

I've also made the gauge generator generic, it was needed for https://github.com/radicle-dev/radicle-registry/issues/409, but it seems unsolvable, so I've reverted it. I like this genericness and it may be useful soon, so I've kept it. The current master of substrate already reexports the whole `prometheus`.