### PR TITLE
cli: Version the key_pair_storage file

### DIFF
--- a/cli/src/command/key_pair.rs
+++ b/cli/src/command/key_pair.rs
@@ -55,6 +55,7 @@ impl CommandT for Generate {
         Ok(())
     }
 }
+
 #[derive(StructOpt, Clone)]
 pub struct List {}
 


### PR DESCRIPTION
Closes #427 

### Changes

- Use json serde adjacent enums to easily serialize and deserialize a versioned `key-pairs.json` file.

- ~~Add a migrations pipeline, where every new migration will be piped in the right sequence. See `key_pair_storage::migrate()`.~~

- Other minor improvements

#### :thinking: :thought_balloon: to think about

~~As of now~~ Before https://github.com/radicle-dev/radicle-registry/pull/448/commits/ca98fdd0029a7377231046783159985006e63e5c, we preemptively attempted to migrate to a newer version of the schema in `list()`, as that is the method used by all other public methods of `key-pair-storage`. This need arises from the fact that only attempting to migrate if `parse_file` returns something besides the latest file schema is not good enough since `parse_file` calls `get_or_create_path()`, which - as it suggests - will create `key-pairs.json` if it doesn't exist yet. If the user has the very first version of the key pair storage, `accounts.json`, this will result in a new, empty `key-pairs.json` file being created, which will by default be in the latest version. This isn't a problem on master since we do this migration step within `get_or_create_path`, here moved to the migrations pipeline.

While this works and has some benefits, such as not requiring any work from the user, it is a bullet waiting to be shot at our feet, since it made correct by coding it so, not by design.

_How can we improve this_

Don't be smart. setting things up if not there yet but separate concerns by adding two new commands:

1. `key-pair init`
    - Setup the directory - create it, check permissions, etc
    - create the key-pairs file for the first time OR migrate it to the latest version
    Should only be run _once_, when the user has installed the CLI.

2. `key-pair migrate`
     Run when the user has updated the CLI to a newer version which requires the
     file schema to be migrated to a newer version alongside.

Doing so would allow us to separate the concerns and have the rest of the code handling them accordingly: If the file is not present, it would fail with an IO error saying the file doesn't exist or cant be read. If outdated, return an error stating precisely that. Note that doing this would also help us have less mixture between pure code and side-effects, and less mix between the path we are concerned with and setting things up along the way.

I would prefer to address this in a separate issue.