### PR TITLE
cli: extract key pair storage init

### DIFF
--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -22,8 +22,35 @@ use std::collections::HashMap;
 use std::fs::File;
 use thiserror::Error as ThisError;
 
+use lazy_static::lazy_static;
 use std::io::Error as IOError;
 use std::path::{Path, PathBuf};
+
+lazy_static! {
+    /// The file where the key pairs are stored.
+    static ref FILE: PathBuf = build_path("key-pairs.json");
+}
+
+/// The possible file variants to be handled when deserializing FILE.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum KeyStorageFile {
+    /// The genesis, unversioned file variant.
+    Unversioned(HashMap<String, KeyPairData>),
+
+    /// A versioned file variant, to which we have moved to
+    /// in order to leverage backwards-compatibility.
+    Versioned(VersionedFile),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "version")]
+enum VersionedFile {
+    #[serde(rename = "1")]
+    V1 {
+        key_pairs: HashMap<String, KeyPairData>,
+    },
+}
 
 /// The data that is stored in the filesystem relative
 /// to a key pair. The name of the key pair is used as
@@ -65,11 +92,10 @@ pub enum Error {
 }
 
 fn io_error_message(action: &str) -> String {
-    let path = build_path(FILE);
     format!(
         "Failed to {} the key-pairs file: '{}'",
         action,
-        path.display()
+        FILE.display()
     )
 }
 
@@ -93,6 +119,20 @@ pub enum ReadingError {
     Deserialization(serde_json::Error),
 }
 
+/// List all the stored key pairs.
+///
+/// Preemptively [init()]s the storage on disk and checks permissions.
+/// It can fail from IO errors or Serde Json errors.
+pub fn list() -> Result<HashMap<String, KeyPairData>, Error> {
+    use {KeyStorageFile::*, VersionedFile::*};
+
+    init()?;
+    match parse_file()? {
+        Unversioned(key_pairs) => Ok(key_pairs),
+        Versioned(V1 { key_pairs }) => Ok(key_pairs),
+    }
+}
+
 /// Add a key pair to the storage.
 ///
 /// Fails if a key pair with the given `name` already exists.
@@ -107,20 +147,6 @@ pub fn add(name: String, data: KeyPairData) -> Result<(), Error> {
     update(key_pairs)
 }
 
-/// List all the stored key-pairs.
-///
-/// It can fail from IO errors or Serde Json errors.
-/// Attempts to migrate the key-pairs file if outdated.
-pub fn list() -> Result<HashMap<String, KeyPairData>, Error> {
-    use {KeyStorageFile::*, VersionedFile::*};
-
-    init()?;
-    match parse_file()? {
-        Unversioned(key_pairs) => Ok(key_pairs),
-        Versioned(V1 { key_pairs }) => Ok(key_pairs),
-    }
-}
-
 /// Get a key pair by name.
 ///
 /// It can fail from IO and Serde Json errors, or if no such
@@ -131,14 +157,15 @@ pub fn get(name: &str) -> Result<KeyPairData, Error> {
 
 fn update(key_pairs: HashMap<String, KeyPairData>) -> Result<(), Error> {
     let data = VersionedFile::V1 { key_pairs };
-    let path_buf = build_path(FILE);
     let new_content = serde_json::to_string_pretty(&data).map_err(WritingError::Serialization)?;
-    std::fs::write(path_buf.as_path(), new_content.as_bytes()).map_err(WritingError::IO)?;
+    std::fs::write(FILE.as_path(), new_content.as_bytes()).map_err(WritingError::IO)?;
     Ok(())
 }
 
-/// The file where the user key-pairs are stored.
-const FILE: &str = "key-pairs.json";
+fn parse_file() -> Result<KeyStorageFile, Error> {
+    let file = File::open(FILE.as_path()).map_err(ReadingError::IO)?;
+    serde_json::from_reader(&file).map_err(|e| ReadingError::Deserialization(e).into())
+}
 
 /// Build the path to the given filename under [dir()].
 fn build_path(filename: &str) -> PathBuf {
@@ -152,62 +179,33 @@ fn dir() -> PathBuf {
         .join("radicle-registry-cli")
 }
 
-fn parse_file() -> Result<KeyStorageFile, Error> {
-    let path_buf = build_path(FILE);
-    let file = File::open(path_buf.as_path()).map_err(ReadingError::IO)?;
-
-    serde_json::from_reader(&file).map_err(|e| ReadingError::Deserialization(e).into())
-}
-
-/// The possible file variants to be handled when deserialization [FILE].
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-enum KeyStorageFile {
-    /// The genesis, unversioned file variant.
-    Unversioned(HashMap<String, KeyPairData>),
-
-    /// A versioned file variant, to which we have moved to
-    /// in order to leverage backwards-compatibility.
-    Versioned(VersionedFile),
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "version")]
-enum VersionedFile {
-    #[serde(rename = "1")]
-    V1 {
-        key_pairs: HashMap<String, KeyPairData>,
-    },
-}
-
 /// Initialize the storage on disk to be used correctly.
 ///   * Create the directory structure and check permissions
-///   * Create and initialize the [FILE] where the key pairs will be stored.
+///   * Create and initialize the FILE where the key pairs will be stored.
 fn init() -> Result<(), Error> {
-    let path_buf = build_path(FILE);
-    let path = path_buf.as_path();
-
-    init_dir(path.parent().unwrap().to_path_buf())?;
-    init_file(path)?;
+    let dir = FILE.parent().unwrap();
+    init_dir(&dir)?;
+    init_file(&FILE)?;
     Ok(())
 }
 
-/// Ensure that the given directory path is ready to be used.
+/// Initialize the given directory to be used.
 /// Fails with
 ///   * [Error::CannotCreateDirectory] if the directory
 ///     does not exist and fails to be created.
 ///   * [Error::CannotReadDirectory] if the directory
-///     does exist but can not be read.
-fn init_dir(dir: PathBuf) -> Result<PathBuf, Error> {
-    std::fs::create_dir_all(&dir).map_err(|err| Error::CannotCreateDirectory(err, dir.clone()))?;
-    File::open(&dir).map_err(|err| Error::CannotReadDirectory(err, dir.clone()))?;
-    Ok(dir)
+///     does exist but cannot be read.
+fn init_dir(dir: &Path) -> Result<(), Error> {
+    std::fs::create_dir_all(&dir)
+        .map_err(|err| Error::CannotCreateDirectory(err, dir.to_path_buf()))?;
+    File::open(dir).map_err(|err| Error::CannotReadDirectory(err, dir.to_path_buf()))?;
+    Ok(())
 }
 
 /// Init the key-pair storage file on disk.
 ///
-/// Renames the legacy `accounts.json` file to [FILE] and creates
-/// [FILE] an empty value to be deserializable if it doesn't exist.
+///   * Rename the legacy `accounts.json` file to the FILE name.
+///   * Create FILE if it doesn't yet exist.
 fn init_file(path: &Path) -> Result<(), Error> {
     if !path.exists() {
         let old_path = build_path("accounts.json");

--- a/cli/src/key_pair_storage.rs
+++ b/cli/src/key_pair_storage.rs
@@ -214,7 +214,7 @@ fn init_file(path: &Path) -> Result<(), Error> {
         if old_path.exists() {
             std::fs::rename(old_path, path).map_err(WritingError::IO)?;
         } else {
-            std::fs::write(path, b"{}").map_err(WritingError::IO)?;
+            update(HashMap::new())?;
         }
     }
 


### PR DESCRIPTION
A humble follow up of the issue described in the description of #448

### Problem

We currently have `get_or_create_path()` that, as the name suggests, builds the path to the storage file but it also creates the storage file it doesn't exist, renames the legacy file if present, creates its parent directory, checks for permissions, etc. That means that every time we simply wan to get the path we have these side effects taking place, which makes the code less reusable and composable.

### Changes

Extract the 'init' code from `get_or_create_path()` to `init()`, which is run preemptively in `list()`, the function that all other pub fn use.

This grants us a better separation of concerns, where now the rest of the code can purely compute the file path and operate on it without the side effects involved.

I don't find this to be a definitive solution (See the linked [PR description](https://github.com/radicle-dev/radicle-registry/pull/448#issue-415912111)) but it's a small step forward in the right direction.

Note: The last commit improves the code organization of the `key_pair_storage_ file and fixes docs, which increases the diff. I suggest checking each commit individually.