### PR TITLE
Add a member to an org

### DIFF
--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -59,6 +59,25 @@ impl Message for message::RegisterProject {
     }
 }
 
+impl Message for message::RegisterMember {
+    type Result = Result<(), TransactionError>;
+
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let dispatch_result = get_dispatch_result(&events)?;
+        match dispatch_result {
+            Ok(()) => find_event(&events, "MemberRegistered", |event| match event {
+                Event::registry(registry::Event::MemberRegistered(_, _)) => Some(Ok(())),
+                _ => None,
+            }),
+            Err(dispatch_error) => Ok(Err(dispatch_error)),
+        }
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        registry::Call::register_member(self).into()
+    }
+}
+
 impl Message for message::RegisterOrg {
     type Result = Result<(), TransactionError>;
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -70,6 +70,9 @@ pub enum RegistryError {
     #[cfg_attr(feature = "std", error("a user with the same ID already exists."))]
     DuplicateUserId,
 
+    #[cfg_attr(feature = "std", error("the user is already a member of the org"))]
+    AlreadyAMember,
+
     #[cfg_attr(feature = "std", error("the provided fee is insufficient"))]
     InsufficientFee,
 

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -92,6 +92,31 @@ pub struct UnregisterUser {
     pub user_id: Id,
 }
 
+/// Register a new member for an org on the Registry with the given user ID.
+///
+/// # State changes
+///
+/// If successful, the `user_id` is added to [crate::state::Org::members] of `org_id` .
+///
+/// # State-dependent validations
+///
+/// The identified org must exit.
+///
+/// The user associated with the author must be a member of the identified org.
+///
+/// A user associated with the `user_id` must exist.
+///
+/// The `user_id` must not already be a member of the org.
+///
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct RegisterMember {
+    // The member to register, unique in the org.
+    pub user_id: Id,
+
+    /// The org in which to register the member.
+    pub org_id: Id,
+}
+
 /// Register a project on the Radicle Registry with the given ID.
 ///
 /// # State changes

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -154,6 +154,16 @@ impl Org {
         }
         self
     }
+
+    /// Add the given user to the list of [Org::members].
+    /// Return a new Org with the new member included or the
+    /// same org if the org already contains that member.
+    pub fn add_member(mut self, user_id: Id) -> Org {
+        if !self.members.contains(&user_id) {
+            self.members.push(user_id);
+        }
+        self
+    }
 }
 
 /// # Storage

--- a/runtime-tests/tests/member_registration.rs
+++ b/runtime-tests/tests/member_registration.rs
@@ -1,0 +1,245 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/// Runtime tests implemented with [MemoryClient].
+///
+/// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
+///
+/// The tests in this module concern project registration.
+use radicle_registry_client::*;
+use radicle_registry_test_utils::*;
+
+#[async_std::test]
+async fn register_member() {
+    let client = Client::new_emulator();
+    let (author, author_id) = key_pair_with_associated_user(&client).await;
+    let (_, member_user_id) = key_pair_with_associated_user(&client).await;
+
+    let register_org = random_register_org_message();
+    submit_ok(&client, &author, register_org.clone()).await;
+
+    // The org needs funds to submit transactions.
+    let org = client
+        .get_org(register_org.org_id.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    let initial_balance = 1000;
+    transfer(&client, &author, org.account_id, initial_balance).await;
+
+    let random_fee = random_balance();
+    let message = message::RegisterMember {
+        org_id: register_org.org_id.clone(),
+        user_id: member_user_id,
+    };
+    let tx_applied = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
+
+    assert_eq!(
+        tx_applied.events[0],
+        RegistryEvent::MemberRegistered(message.clone().user_id, message.clone().org_id).into()
+    );
+
+    // Fetch the org again
+    let re_org = client
+        .get_org(message.clone().org_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(re_org.members.len(), 2);
+    assert!(
+        re_org.members.contains(&author_id),
+        "Org does not contain the founding member."
+    );
+    assert!(
+        re_org.members.contains(&message.clone().user_id),
+        "Org does not contain the added member."
+    );
+
+    assert_eq!(
+        client.free_balance(&re_org.account_id).await.unwrap(),
+        initial_balance - random_fee,
+        "The tx fee was not charged properly."
+    );
+}
+
+#[async_std::test]
+async fn register_member_with_inexistent_org() {
+    let client = Client::new_emulator();
+    let (author, user_id) = key_pair_with_associated_user(&client).await;
+    let initial_balance = client.free_balance(&author.public()).await.unwrap();
+
+    let random_fee = random_balance();
+    let inexistent_org_id = random_id();
+    let message = message::RegisterMember {
+        org_id: inexistent_org_id,
+        user_id,
+    };
+    let tx_applied = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
+
+    assert_eq!(tx_applied.result, Err(RegistryError::InexistentOrg.into()));
+
+    // Check that the author payed for the transaction anyway.
+    assert_eq!(
+        client.free_balance(&author.public()).await.unwrap(),
+        initial_balance - random_fee,
+        "The tx fee was not charged properly."
+    );
+}
+
+#[async_std::test]
+async fn register_member_with_bad_actor() {
+    let client = Client::new_emulator();
+    let (good_actor, good_actor_id) = key_pair_with_associated_user(&client).await;
+    let (bad_actor, bad_actor_id) = key_pair_with_associated_user(&client).await;
+
+    // The good actor creates an org, of which becomes its single member.
+    let org_id = random_id();
+    let register_org = message::RegisterOrg {
+        org_id: org_id.clone(),
+    };
+    submit_ok(&client, &good_actor, register_org.clone()).await;
+
+    // The bad actor attempts to register themselves as a member within that org.
+    let initial_balance = client.free_balance(&bad_actor.public()).await.unwrap();
+    let register_member = message::RegisterMember {
+        org_id,
+        user_id: bad_actor_id,
+    };
+    let random_fee = random_balance();
+    let tx_applied =
+        submit_ok_with_fee(&client, &bad_actor, register_member.clone(), random_fee).await;
+
+    assert_eq!(
+        tx_applied.result,
+        Err(RegistryError::InsufficientSenderPermissions.into())
+    );
+
+    // Check that the bad actor payed for the transaction anyway.
+    assert_eq!(
+        client.free_balance(&bad_actor.public()).await.unwrap(),
+        initial_balance - random_fee,
+        "The tx fee was not charged properly."
+    );
+
+    // Re-fetch the org and check that the bad actor was not added as a member
+    let re_org = client
+        .get_org(register_member.clone().org_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(re_org.members, vec![good_actor_id]);
+}
+
+#[async_std::test]
+async fn register_duplicate_member() {
+    let client = Client::new_emulator();
+    let (author, author_id) = key_pair_with_associated_user(&client).await;
+
+    // Register the org.
+    let org_id = random_id();
+    let register_org = message::RegisterOrg {
+        org_id: org_id.clone(),
+    };
+    submit_ok(&client, &author, register_org.clone()).await;
+
+    // The org needs funds to submit transactions.
+    let org = client
+        .get_org(register_org.org_id.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    let initial_balance = 1000;
+    transfer(&client, &author, org.account_id, initial_balance).await;
+
+    // The author attempts to register themselves as a member within that org again.
+    let register_member = message::RegisterMember {
+        org_id,
+        user_id: author_id.clone(),
+    };
+    let random_fee = random_balance();
+    let tx_applied =
+        submit_ok_with_fee(&client, &author, register_member.clone(), random_fee).await;
+
+    assert_eq!(tx_applied.result, Err(RegistryError::AlreadyAMember.into()));
+
+    // Re-fetch the org
+    let re_org = client
+        .get_org(register_member.clone().org_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Check that the org payed for the transaction anyway.
+    assert_eq!(
+        client.free_balance(&re_org.account_id).await.unwrap(),
+        initial_balance - random_fee,
+        "The tx fee was not charged properly."
+    );
+
+    // Check that the author was not added again
+    assert_eq!(re_org.members, vec![author_id]);
+}
+
+#[async_std::test]
+async fn register_nonexistent_user() {
+    let client = Client::new_emulator();
+    let (author, author_id) = key_pair_with_associated_user(&client).await;
+
+    // Register the org.
+    let org_id = random_id();
+    let register_org = message::RegisterOrg {
+        org_id: org_id.clone(),
+    };
+    submit_ok(&client, &author, register_org.clone()).await;
+
+    // The org needs funds to submit transactions.
+    let org = client
+        .get_org(register_org.org_id.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    let initial_balance = 1000;
+    transfer(&client, &author, org.account_id, initial_balance).await;
+
+    // Attempt to register a non-existent user as a member.
+    let register_member = message::RegisterMember {
+        org_id,
+        user_id: random_id(),
+    };
+    let random_fee = random_balance();
+    let tx_applied =
+        submit_ok_with_fee(&client, &author, register_member.clone(), random_fee).await;
+
+    assert_eq!(tx_applied.result, Err(RegistryError::InexistentUser.into()));
+
+    // Re-fetch the org
+    let re_org = client
+        .get_org(register_member.clone().org_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Check that the org payed for the transaction anyway.
+    assert_eq!(
+        client.free_balance(&re_org.account_id).await.unwrap(),
+        initial_balance - random_fee,
+        "The tx fee was not charged properly."
+    );
+
+    // Check that no new member was added
+    assert_eq!(re_org.members, vec![author_id]);
+}

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -67,6 +67,7 @@ fn payer_account(author: AccountId, call: &Call) -> AccountId {
             RegistryCall::unregister_org(m) => org_payer_account(author, &m.org_id),
             RegistryCall::transfer_from_org(m) => org_payer_account(author, &m.org_id),
             RegistryCall::set_checkpoint(m) => org_payer_account(author, &m.org_id),
+            RegistryCall::register_member(m) => org_payer_account(author, &m.org_id),
 
             // Transactions paid by the author
             RegistryCall::create_checkpoint(_)


### PR DESCRIPTION
Add the functionality to add a member to an existing org. 

Todos:
- [x] add more runtime tests
  - [x] bad author scenario, where the said author would pay the fee
  - [x] no org scenario, where the said author would pay the fee
  - [x] no user associated scenario, where the said author would pay the fee
- [x] add end-to-end tests
- [x] add cli functionality
- [x] error out if an existing member is added again

In a follow up, the functionality to remove a member should be added