### PR TITLE
Add CLI command to submit new wasm runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Upcoming
 * Polkadot telemetry was removed
 
 ### Addition
+
+* cli: Add `update-runtime` command to update the on-chain runtime
 * cli: Mutually support local account names where only SS58 address were
   supported as params.
 * Add `user list` and `user show` CLI commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ dependencies = [
  "jsonrpc-core-client",
  "lazy_static",
  "log 0.4.8",
+ "pallet-sudo",
  "parity-scale-codec",
  "radicle-registry-core",
  "radicle-registry-runtime",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -162,7 +162,11 @@ runtime.
 ```
 
 For semantic updates to take effect on an existing chain they need to be
-deployed to the chain. This process has not been established yet.
+deployed to the chain.
+
+```
+radicle-registry-cli update-runtime ./runtime/latest.wasm --author <sudo_key> --node-host <node_host>
+```
 
 Changes to the chain state must be backwards-compatibility, requiring particular
 attention. A policy and process for such updates have not been established yet.

--- a/cli/src/command/other.rs
+++ b/cli/src/command/other.rs
@@ -23,6 +23,13 @@ use super::*;
 pub enum Command {
     /// Show the genesis hash the node uses
     GenesisHash(ShowGenesisHash),
+
+    /// Submit a transaction to update the on-chain runtime.
+    /// Requirements:
+    ///   * the tx author must be the chain's sudo key
+    ///   * the `spec_version` of the given wasm runtime must be greater than the chain runtime's.
+    ///   * the `spec_name` must match between the wasm runtime and the chain runtime.
+    UpdateRuntime(UpdateRuntime),
 }
 
 #[async_trait::async_trait]
@@ -30,6 +37,7 @@ impl CommandT for Command {
     async fn run(self) -> Result<(), CommandError> {
         match self {
             Command::GenesisHash(cmd) => cmd.run().await,
+            Command::UpdateRuntime(cmd) => cmd.run().await,
         }
     }
 }
@@ -46,6 +54,42 @@ impl CommandT for ShowGenesisHash {
         let client = self.network_options.client().await?;
         let genesis_hash = client.genesis_hash();
         println!("Genesis block hash: 0x{}", hex::encode(genesis_hash));
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Clone)]
+pub struct UpdateRuntime {
+    /// The path to the (wasm) runtime code to submit
+    path: std::path::PathBuf,
+
+    #[structopt(flatten)]
+    network_options: NetworkOptions,
+
+    #[structopt(flatten)]
+    tx_options: TxOptions,
+}
+
+#[async_trait::async_trait]
+impl CommandT for UpdateRuntime {
+    async fn run(self) -> Result<(), CommandError> {
+        let client = self.network_options.client().await?;
+        let new_runtime_code =
+            std::fs::read(self.path).expect("Invalid path or couldn't read the wasm file");
+
+        let update_runtime_fut = client
+            .sign_and_submit_message(
+                &self.tx_options.author,
+                message::UpdateRuntime {
+                    code: new_runtime_code,
+                },
+                self.tx_options.fee,
+            )
+            .await?;
+        announce_tx("Submitting the new on-chain runtime...");
+
+        update_runtime_fut.await?.result?;
+        println!("✓ The new on-chain runtime is now published.");
         Ok(())
     }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,6 +28,12 @@ thiserror = "1.0.14"
 tokio = "0.1"
 url = "1.7"
 
+
+[dependencies.pallet-sudo]
+git = "https://github.com/paritytech/substrate"
+rev = "3f134a1af2462482b2868adf73a050a8da0d3934"
+default_features = false
+
 [dependencies.frame-system]
 git = "https://github.com/paritytech/substrate"
 rev = "3f134a1af2462482b2868adf73a050a8da0d3934"

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -204,6 +204,31 @@ impl Message for message::TransferFromOrg {
     }
 }
 
+impl Message for message::UpdateRuntime {
+    type Result = Result<(), TransactionError>;
+
+    /// The only unequivocal sign we get that a wasm update was successful is the
+    /// `RawEvent::CodeUpdated` event. Anything else is considered a failed update.
+    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+        let error: TransactionError = RegistryError::FailedChainRuntimeUpdate.into();
+        find_event(&events, "System", |event| match event {
+            Event::system(system_event) => match system_event {
+                frame_system::RawEvent::CodeUpdated => Some(Ok(())),
+                _ => Some(Err(error)),
+            },
+            _ => Some(Err(error)),
+        })
+    }
+
+    fn into_runtime_call(self) -> RuntimeCall {
+        let set_code_call: RuntimeCall = frame_system::Call::set_code(self.code).into();
+        let sudo_call: pallet_sudo::Call<Runtime> =
+            pallet_sudo::Call::sudo(Box::new(set_code_call));
+
+        sudo_call.into()
+    }
+}
+
 /// Extract the dispatch result of an extrinsic from the extrinsic events.
 ///
 /// Looks for the [frame_system::Event] in the list of events and returns the inner result based on

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -99,6 +99,18 @@ pub enum RegistryError {
         error("the account is already associated with a user")
     )]
     UserAccountAssociated,
+
+    #[cfg_attr(
+        feature = "std",
+        error(
+            "failed to update the chain runtime. Ensure that:
+    * the author is the chain's sudo key
+    * the 'spec_name' match
+    * the wasm 'spec_version' is greater
+        "
+        )
+    )]
+    FailedChainRuntimeUpdate,
 }
 
 // The index with which the registry runtime module is declared

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -19,6 +19,7 @@
 extern crate alloc;
 
 use crate::{AccountId, Balance, Bytes128, CheckpointId, Id, ProjectName, H256};
+use alloc::prelude::v1::Vec;
 use parity_scale_codec::{Decode, Encode};
 
 /// Registers an org on the Radicle Registry with the given ID.
@@ -199,4 +200,23 @@ pub struct TransferFromOrg {
 pub struct Transfer {
     pub recipient: AccountId,
     pub balance: Balance,
+}
+
+/// Attempts to update the on-chain runtime with the new given one.
+/// The `code` must be a valid WASM module and adhere to the substrate runtime API.
+///
+/// # State changes
+///
+/// If successful, the given `code` will be the new one herein.
+///
+/// # State-dependent validations
+///
+/// The tx author must be the chain's sudo key
+///
+/// The `spec_version` of the given runtime code needs to be greater than
+/// the `spec_version` of the chain runtime.
+///
+#[derive(Decode, Encode, Clone, Debug, Eq, PartialEq)]
+pub struct UpdateRuntime {
+    pub code: Vec<u8>,
 }


### PR DESCRIPTION
Closes #443 


### `TBD`

- [x] Improve error propagation, reporting the case where the submission fails because the submitted wasm `spec_version` is not greater than the one the runtime of the node we are connected to is running.

~~- [ ] https://github.com/radicle-dev/radicle-registry/pull/452#discussion_r427319736 "There is additional information that we can extract here: We can determine whether the author matches the sudo key. I think this would be valuable to have as an additional error case."~~

~~- [ ] https://github.com/radicle-dev/radicle-registry/pull/452#pullrequestreview-414456802 Add client-side validations~~

**Note**: We can't do this at the moment since we would need to either call `frame_system::Module<T>::can_set_code` or duplicate its logic. I tried the second approach but we can't do either because both call `sp_io::misc::runtime_version`, which fails with `called outside of an Externalities-provided environment.`

### Notes

* Initially I didn't have this transaction as a `message` but ended up switching to that approach to reduce code duplication and use the same infrastructure already in place for all other messages. Some parts are necessarily custom but this approach still feels better this way

* Regarding the docs for the new `UpdateRuntime` message, I kept the `State changes` and `State-dependent validations` blocks since they are kind of applicable, although not quite the same as the other messages. Let me know how you see it.

* Get a Result from the events obtained from this transactions is not as clean as I'd wish.
  I set it so that when we get a `RawEvent::CodeUpdated` event, it means success. Otherwise, it fails with the new error `FailedRuntimeWasmUpdate`, since when the update fails we don't get any useful dispatch error nor a useful event.

* See https://github.com/radicle-dev/radicle-registry/pull/452#issuecomment-630034545 to learn how to run this locally successfully.