### PR TITLE
Add control interface for client emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* client: `Client::new_emulator()` now returns a pair of a `Client` and
+  `EmulatorControl`.
 * cli: Move `update-runtime` to `runtime update`
 * Rename `TransactionApplied` to `TransactionIncluded`
 * cli: Rename the key-pair storage file from 'accounts.json' to 'key-pairs.json'

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Developing with the Client
 --------------------------
 
 For development you can create a ledger emulator with
-`radicle-registry-client::Client::new_emulator()`. Instead of connecting to a
+`radicle_registry_client::Client::new_emulator()`. Instead of connecting to a
 node this client runs the ledger in memory. See the API docs for more
 information.
 

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -19,12 +19,12 @@ use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use sp_runtime::{traits::Hash as _, BuildStorage as _, Digest};
+use sp_runtime::{traits::Block as _, traits::Hash as _, BuildStorage as _, Digest};
 use sp_state_machine::backend::Backend as _;
 
 use radicle_registry_runtime::{
-    registry, runtime_api, AccountId, BalancesConfig, GenesisConfig, Hash, Hashing, Header,
-    Runtime, RuntimeVersion,
+    registry, runtime_api, AccountId, BalancesConfig, Block, EventRecord, GenesisConfig, Hash,
+    Hashing, Header, Runtime, RuntimeVersion,
 };
 
 use crate::backend;
@@ -32,6 +32,8 @@ use crate::interface::*;
 
 /// [backend::Backend] implementation using native runtime code and in memory state through
 /// [sp_io::TestExternalities] to emulate the ledger.
+///
+/// The clone of an [Emulator] will share the state with the original emulator using a [Mutex].
 ///
 /// # Differences with real backend
 ///
@@ -46,6 +48,35 @@ pub struct Emulator {
     genesis_hash: Hash,
     inherent_data_providers: sp_inherents::InherentDataProviders,
     state: Arc<Mutex<EmulatorState>>,
+}
+
+/// Control handle to manipulate the state of [Emulator].
+///
+/// Construct this with [Emulator::control].
+///
+/// Cloning [EmulatorControl] will create another handle to manipulate the same emulator.
+#[derive(Clone)]
+pub struct EmulatorControl(Emulator);
+
+impl EmulatorControl {
+    /// Adds `count` number of empty blocks to the emulator chain.
+    ///
+    /// ```
+    /// # #[async_std::main]
+    /// # async fn main () {
+    /// # use radicle_registry_client::{Client, ClientT};
+    /// let (client, emulator) = Client::new_emulator();
+    /// let header1 = client.block_header_best_chain().await.unwrap();
+    /// emulator.add_blocks(3);
+    /// let header2 = client.block_header_best_chain().await.unwrap();
+    /// assert_eq!(header2.number, header1.number + 3)
+    /// # }
+    /// ```
+    pub fn add_blocks(&self, count: u32) {
+        for _ in 0..count {
+            self.0.add_block(vec![]);
+        }
+    }
 }
 
 /// Mutable state of the emulator.
@@ -98,6 +129,44 @@ impl Emulator {
             })),
         }
     }
+
+    pub fn control(&self) -> EmulatorControl {
+        EmulatorControl(self.clone())
+    }
+
+    /// Add a block with `extrinsics` to the chain. Returns the added block and a list of events
+    /// recorded during the execution of the block.
+    fn add_block(&self, extrinsics: Vec<backend::UncheckedExtrinsic>) -> (Block, Vec<EventRecord>) {
+        let mut state = self.state.lock().unwrap();
+
+        let new_tip_header_init = Header {
+            parent_hash: state.tip_header.hash(),
+            number: state.tip_header.number + 1,
+            ..state.tip_header.clone()
+        };
+
+        let (block, event_records) = state.test_ext.execute_with(move || {
+            runtime_api::initialize_block(&new_tip_header_init);
+
+            let inherent_data = self.inherent_data_providers.create_inherent_data().unwrap();
+            let inherents = runtime_api::inherent_extrinsics(inherent_data);
+            let extrinsics = [inherents, extrinsics].concat();
+
+            for extrinsic in &extrinsics {
+                let _apply_result = runtime_api::apply_extrinsic(extrinsic.clone()).unwrap();
+            }
+
+            let header = runtime_api::finalize_block();
+            let event_records = frame_system::Module::<Runtime>::events();
+
+            (Block { header, extrinsics }, event_records)
+        });
+
+        state.tip_header = block.header.clone();
+        state.headers.insert(block.hash(), block.header.clone());
+
+        (block, event_records)
+    }
 }
 
 #[async_trait::async_trait]
@@ -107,45 +176,16 @@ impl backend::Backend for Emulator {
         extrinsic: backend::UncheckedExtrinsic,
     ) -> Result<BoxFuture<'static, Result<backend::TransactionIncluded, Error>>, Error> {
         let tx_hash = Hashing::hash_of(&extrinsic);
-        let mut state = self.state.lock().unwrap();
+        let (block, event_records) = self.add_block(vec![extrinsic]);
 
-        let new_tip_header_init = Header {
-            parent_hash: state.tip_header.hash(),
-            number: state.tip_header.number + 1,
-            ..state.tip_header.clone()
-        };
-
-        let (new_tip_header, events) = state.test_ext.execute_with(move || {
-            runtime_api::initialize_block(&new_tip_header_init);
-
-            let inherent_data = self.inherent_data_providers.create_inherent_data().unwrap();
-            let inherents = runtime_api::inherent_extrinsics(inherent_data);
-            for inherent in inherents {
-                let _apply_result = runtime_api::apply_extrinsic(inherent).unwrap();
-            }
-
-            let event_start_index = frame_system::Module::<Runtime>::event_count();
-            // We ignore the dispatch result. It is provided through the system event
-            // TODO Pass on apply errors instead of unwrapping.
-            let _apply_result = runtime_api::apply_extrinsic(extrinsic).unwrap();
-            let events = frame_system::Module::<Runtime>::events()
-                .into_iter()
-                .skip(event_start_index as usize)
-                .map(|event_record| event_record.event)
-                .collect::<Vec<Event>>();
-
-            let header = runtime_api::finalize_block();
-            (header, events)
-        });
-
-        state.tip_header = new_tip_header.clone();
-        let new_tip_hash = new_tip_header.hash();
-        state.headers.insert(new_tip_hash, new_tip_header);
+        let events =
+            crate::backend::remote_node::extract_transaction_events(tx_hash, &block, event_records)
+                .unwrap();
 
         Ok(Box::pin(futures::future::ready(Ok(
             backend::TransactionIncluded {
                 tx_hash,
-                block: new_tip_hash,
+                block: block.hash(),
                 events,
             },
         ))))

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -24,7 +24,7 @@ mod emulator;
 mod remote_node;
 mod remote_node_with_executor;
 
-pub use emulator::{Emulator, BLOCK_AUTHOR as EMULATOR_BLOCK_AUTHOR};
+pub use emulator::{Emulator, EmulatorControl, BLOCK_AUTHOR as EMULATOR_BLOCK_AUTHOR};
 pub use remote_node::RemoteNode;
 pub use remote_node_with_executor::RemoteNodeWithExecutor;
 

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -146,7 +146,7 @@ impl RemoteNode {
         let block = opt_block.ok_or_else(|| {
             Error::from("Block that should include submitted transaction does not exist")
         })?;
-        extract_transaction_events(tx_hash, block, event_records)
+        extract_transaction_events(tx_hash, &block, event_records)
             .ok_or_else(|| Error::from("Failed to extract transaction events"))
     }
 }
@@ -231,9 +231,9 @@ impl backend::Backend for RemoteNode {
 ///
 /// Returns `None` if no events for the transaction were found. This should be treated as an error
 /// since the events should at least include the system event for the transaction.
-fn extract_transaction_events(
+pub(crate) fn extract_transaction_events(
     tx_hash: TxHash,
-    block: Block,
+    block: &Block,
     event_records: Vec<EventRecord>,
 ) -> Option<Vec<Event>> {
     let xt_index = block

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -49,7 +49,7 @@ pub use crate::interface::*;
 pub use radicle_registry_core::Balance;
 pub use radicle_registry_runtime::fees::MINIMUM_FEE;
 
-pub use backend::EMULATOR_BLOCK_AUTHOR;
+pub use backend::{EmulatorControl, EMULATOR_BLOCK_AUTHOR};
 
 /// Client to interact with the radicle registry ledger via an implementation of [ClientT].
 ///
@@ -79,10 +79,14 @@ impl Client {
         Ok(Self::new(backend))
     }
 
-    /// Create a new client that emulates the registry ledger in memory. See
-    /// [backend::emulator::Emulator] for details.
-    pub fn new_emulator() -> Self {
-        Self::new(backend::Emulator::new())
+    /// Create a new client that emulates the registry ledger in memory. Also returns a control
+    /// handle to manipulate the emulator state. See [backend::Emulator] and [EmulatorControl] for
+    /// details.
+    pub fn new_emulator() -> (Self, EmulatorControl) {
+        let emulator = backend::Emulator::new();
+        let control = emulator.control();
+        let client = Self::new(emulator);
+        (client, control)
     }
 
     fn new(backend: impl backend::Backend + Sync + Send + 'static) -> Self {
@@ -321,6 +325,6 @@ mod test {
     #[allow(dead_code)]
     fn client_is_sync_send_static() {
         fn is_sync_send(_x: impl Sync + Send + 'static) {}
-        is_sync_send(Client::new_emulator());
+        is_sync_send(Client::new_emulator().0);
     }
 }

--- a/runtime-tests/tests/block_rewards.rs
+++ b/runtime-tests/tests/block_rewards.rs
@@ -21,7 +21,7 @@ use sp_runtime::Permill;
 /// Assert that block rewards and transaction fees are credited to the block author.
 #[async_std::test]
 async fn block_rewards_credited() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
 
     let alice = key_pair_from_string("Alice");
     let bob = key_pair_from_string("Bob").public();

--- a/runtime-tests/tests/checkpoing_setting.rs
+++ b/runtime-tests/tests/checkpoing_setting.rs
@@ -24,7 +24,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn create_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
@@ -68,7 +68,7 @@ async fn create_checkpoint() {
 
 #[async_std::test]
 async fn set_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
@@ -119,7 +119,7 @@ async fn set_checkpoint() {
 
 #[async_std::test]
 async fn set_checkpoint_without_permission() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
@@ -167,7 +167,7 @@ async fn set_checkpoint_without_permission() {
 
 #[async_std::test]
 async fn fail_to_set_nonexistent_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
@@ -201,7 +201,7 @@ async fn fail_to_set_nonexistent_checkpoint() {
 
 #[async_std::test]
 async fn set_fork_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
@@ -266,7 +266,7 @@ async fn set_fork_checkpoint() {
 // test that the bad actor pays the tx fee nonetheless.
 #[async_std::test]
 async fn set_checkpoint_bad_actor() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();

--- a/runtime-tests/tests/checkpoint_creation.rs
+++ b/runtime-tests/tests/checkpoint_creation.rs
@@ -23,7 +23,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn create_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
 
     let project_hash1 = H256::random();
@@ -77,7 +77,7 @@ async fn create_checkpoint() {
 
 #[async_std::test]
 async fn create_checkpoint_without_parent() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
 
     let project_hash = H256::random();

--- a/runtime-tests/tests/org_registration.rs
+++ b/runtime-tests/tests/org_registration.rs
@@ -23,7 +23,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn register_org() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let initial_balance = client.free_balance(&author.public()).await.unwrap();
@@ -60,7 +60,7 @@ async fn register_org() {
 
 #[async_std::test]
 async fn register_with_duplicated_org_id() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
     let register_org_message = random_register_org_message();
 
@@ -76,7 +76,7 @@ async fn register_with_duplicated_org_id() {
 
 #[async_std::test]
 async fn unregister_org() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let register_org_message = random_register_org_message();
@@ -125,7 +125,7 @@ async fn unregister_org() {
 
 #[async_std::test]
 async fn unregister_org_bad_actor() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
     let register_org_message = random_register_org_message();
 
@@ -174,7 +174,7 @@ async fn unregister_org_bad_actor() {
 
 #[async_std::test]
 async fn unregister_org_with_projects() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();

--- a/runtime-tests/tests/project_registration.rs
+++ b/runtime-tests/tests/project_registration.rs
@@ -23,7 +23,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn register_project() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let project_hash = H256::random();
@@ -106,7 +106,7 @@ async fn register_project() {
 
 #[async_std::test]
 async fn register_project_with_inexistent_org() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let project_hash = H256::random();
@@ -131,7 +131,7 @@ async fn register_project_with_inexistent_org() {
 
 #[async_std::test]
 async fn register_project_with_duplicate_id() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let checkpoint_id = submit_ok(
@@ -195,7 +195,7 @@ async fn register_project_with_duplicate_id() {
 
 #[async_std::test]
 async fn register_project_with_bad_checkpoint() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let checkpoint_id = H256::random();
@@ -227,7 +227,7 @@ async fn register_project_with_bad_checkpoint() {
 
 #[async_std::test]
 async fn register_project_with_bad_actor() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (good_actor, _) = key_pair_with_associated_user(&client).await;
     let (bad_actor, _) = key_pair_with_associated_user(&client).await;
 

--- a/runtime-tests/tests/transfer.rs
+++ b/runtime-tests/tests/transfer.rs
@@ -23,7 +23,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn transfer_fail() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let bob = key_pair_from_string("Bob").public();
 
@@ -44,7 +44,7 @@ async fn transfer_fail() {
 // Affected by the [crate::ExistentialDeposit] parameter.
 #[async_std::test]
 async fn transfer_any_amount() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let donator = key_pair_from_string("Alice");
     let receipient = key_pair_from_string("Bob").public();
 
@@ -71,7 +71,7 @@ async fn transfer_any_amount() {
 /// org owner can transfer money from an org to another account.
 #[async_std::test]
 async fn org_account_transfer() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
     let bob = key_pair_from_string("Bob").public();
@@ -123,7 +123,7 @@ async fn org_account_transfer() {
 #[async_std::test]
 /// Test that a transfer from an org account fails if the sender is not an org member.
 async fn org_account_transfer_non_member() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
     let org = create_random_org(&client, &author).await;
 

--- a/runtime-tests/tests/user_registration.rs
+++ b/runtime-tests/tests/user_registration.rs
@@ -23,7 +23,7 @@ use radicle_registry_test_utils::*;
 
 #[async_std::test]
 async fn register_user() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let initial_balance = client.free_balance(&alice.public()).await.unwrap();
 
@@ -58,7 +58,7 @@ async fn register_user() {
 
 #[async_std::test]
 async fn register_user_with_duplicate_id() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let register_user_message = random_register_user_message();
 
@@ -74,7 +74,7 @@ async fn register_user_with_duplicate_id() {
 
 #[async_std::test]
 async fn register_user_with_already_associated_account() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let register_first_user_message = random_register_user_message();
 
@@ -92,7 +92,7 @@ async fn register_user_with_already_associated_account() {
 
 #[async_std::test]
 async fn unregister_user() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let register_user_message = random_register_user_message();
 
@@ -130,7 +130,7 @@ async fn unregister_user() {
 
 #[async_std::test]
 async fn unregister_user_with_invalid_sender() {
-    let client = Client::new_emulator();
+    let (client, _) = Client::new_emulator();
     let alice = key_pair_from_string("Alice");
     let register_user_message = random_register_user_message();
 


### PR DESCRIPTION
Adds `EmulatorControl` and `add_blocks()` for #453. This PR does not yet at the capability to produce blocks automatically in the background.

A conscious decision was made to expose a separate `EmulatorControl` struct instead of `Emulator` so that the internal APIs of `Emulator` (e.g. the `Backend` implementation) are not leaked to the user.