### PR TITLE
Use different author for each test

### DIFF
--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -28,12 +28,12 @@ async fn register_project() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let alice = ed25519::Pair::from_string("//Alice", None).unwrap();
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let project_hash = H256::random();
     let checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash,
             previous_checkpoint_id: None,
@@ -47,20 +47,20 @@ async fn register_project() {
     let register_org_message = message::RegisterOrg {
         org_id: org_id.clone(),
     };
-    let org_registered_tx = submit_ok(&client, &alice, register_org_message.clone()).await;
+    let org_registered_tx = submit_ok(&client, &author, register_org_message.clone()).await;
     assert_eq!(org_registered_tx.result, Ok(()));
 
     // The org needs funds to submit transactions.
     let org = client.get_org(org_id.clone()).await.unwrap().unwrap();
     let initial_balance = 1000;
-    transfer(&client, &alice, org.account_id, initial_balance).await;
+    transfer(&client, &author, org.account_id, initial_balance).await;
 
     let register_project_message = random_register_project_message(org_id.clone(), checkpoint_id);
     let project_name = register_project_message.project_name.clone();
     let random_fee = random_balance();
     let tx_included = submit_ok_with_fee(
         &client,
-        &alice,
+        &author,
         register_project_message.clone(),
         random_fee,
     )
@@ -123,13 +123,14 @@ async fn register_org() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let alice = key_pair_from_string("Alice");
-    let initial_balance = client.free_balance(&alice.public()).await.unwrap();
+    let (author, user_id) = key_pair_with_associated_user(&client).await;
+
+    let initial_balance = client.free_balance(&author.public()).await.unwrap();
 
     let register_org_message = random_register_org_message();
     let random_fee = random_balance();
     let tx_included =
-        submit_ok_with_fee(&client, &alice, register_org_message.clone(), random_fee).await;
+        submit_ok_with_fee(&client, &author, register_org_message.clone(), random_fee).await;
 
     assert_eq!(
         tx_included.events[0],
@@ -148,7 +149,7 @@ async fn register_org() {
     assert!(org.projects.is_empty());
 
     assert_eq!(
-        client.free_balance(&alice.public()).await.unwrap(),
+        client.free_balance(&author.public()).await.unwrap(),
         initial_balance - random_fee,
         "The tx fee was not charged properly."
     );
@@ -160,12 +161,10 @@ async fn register_user() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    // Must be distinct sender from other user registrations in tests to avoid
-    // AccountUserAssociated errors.
-    let sender = ed25519::Pair::from_string("//Alice", None).unwrap();
+    let author = ed25519::Pair::from_string("//Alice", None).unwrap();
 
     let register_user_message = random_register_user_message();
-    let tx_included = submit_ok(&client, &sender, register_user_message.clone()).await;
+    let tx_included = submit_ok(&client, &author, register_user_message.clone()).await;
 
     assert_eq!(
         tx_included.events[0],
@@ -188,7 +187,7 @@ async fn register_user() {
     let unregister_user_message = message::UnregisterUser {
         user_id: register_user_message.user_id.clone(),
     };
-    let tx_unregister_applied = submit_ok(&client, &sender, unregister_user_message.clone()).await;
+    let tx_unregister_applied = submit_ok(&client, &author, unregister_user_message.clone()).await;
     assert!(tx_unregister_applied.result.is_ok());
     assert!(
         !user_exists(&client, register_user_message.user_id.clone()).await,

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -123,7 +123,7 @@ async fn register_org() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let (author, user_id) = key_pair_with_associated_user(&client).await;
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let initial_balance = client.free_balance(&author.public()).await.unwrap();
 
@@ -145,7 +145,7 @@ async fn register_org() {
     assert!(opt_org.is_some(), "Registered org not found in orgs list");
     let org = opt_org.unwrap();
     assert_eq!(org.id, register_org_message.org_id);
-    assert_eq!(org.members, vec![alice.public()]);
+    assert_eq!(org.members, vec![author.public()]);
     assert!(org.projects.is_empty());
 
     assert_eq!(

--- a/runtime-tests/tests/checkpoing_setting.rs
+++ b/runtime-tests/tests/checkpoing_setting.rs
@@ -25,17 +25,17 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn create_checkpoint() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
 
-    let initial_balance = client.free_balance(&alice.public()).await.unwrap();
+    let initial_balance = client.free_balance(&author.public()).await.unwrap();
     let project_hash = H256::random();
     let random_fee = random_balance();
     let new_checkpoint_id = submit_ok_with_fee(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash,
             previous_checkpoint_id: Some(project.current_cp),
@@ -60,7 +60,7 @@ async fn create_checkpoint() {
     );
 
     assert_eq!(
-        client.free_balance(&alice.public()).await.unwrap(),
+        client.free_balance(&author.public()).await.unwrap(),
         initial_balance - random_fee,
         "The tx fee was not charged properly."
     );
@@ -69,16 +69,16 @@ async fn create_checkpoint() {
 #[async_std::test]
 async fn set_checkpoint() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
     let project_name = project.clone().name;
 
     let project_hash2 = H256::random();
     let new_checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash: project_hash2,
             previous_checkpoint_id: Some(project.current_cp),
@@ -93,7 +93,7 @@ async fn set_checkpoint() {
     let random_fee = random_balance();
     submit_ok_with_fee(
         &client,
-        &alice,
+        &author,
         message::SetCheckpoint {
             project_name: project.name,
             org_id: project.org_id,
@@ -120,16 +120,16 @@ async fn set_checkpoint() {
 #[async_std::test]
 async fn set_checkpoint_without_permission() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
     let project_name = project.name.clone();
 
     let project_hash2 = H256::random();
     let new_checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash: project_hash2,
             previous_checkpoint_id: Some(project.current_cp),
@@ -139,9 +139,7 @@ async fn set_checkpoint_without_permission() {
     .result
     .unwrap();
 
-    let bad_actor = key_pair_from_string("BadActor");
-    // The bad actor needs funds to submit transactions.
-    transfer(&client, &alice, bad_actor.public(), 1000).await;
+    let (bad_actor, _) = key_pair_with_associated_user(&client).await;
 
     let tx_included = submit_ok(
         &client,
@@ -170,16 +168,16 @@ async fn set_checkpoint_without_permission() {
 #[async_std::test]
 async fn fail_to_set_nonexistent_checkpoint() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
     let project_name = project.name.clone();
     let garbage = CheckpointId::random();
 
     let tx_included = submit_ok(
         &client,
-        &alice,
+        &author,
         message::SetCheckpoint {
             project_name: project.name,
             org_id: project.org_id,
@@ -204,10 +202,10 @@ async fn fail_to_set_nonexistent_checkpoint() {
 #[async_std::test]
 async fn set_fork_checkpoint() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
 
     let project_name = project.name.clone();
     let mut current_cp = project.current_cp;
@@ -218,7 +216,7 @@ async fn set_fork_checkpoint() {
     for _ in 0..n {
         let new_checkpoint_id = submit_ok(
             &client,
-            &alice,
+            &author,
             message::CreateCheckpoint {
                 project_hash: H256::random(),
                 previous_checkpoint_id: (Some(current_cp)),
@@ -233,7 +231,7 @@ async fn set_fork_checkpoint() {
 
     let forked_checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash: H256::random(),
             previous_checkpoint_id: (Some(checkpoints[2])),
@@ -245,7 +243,7 @@ async fn set_fork_checkpoint() {
 
     submit_ok(
         &client,
-        &alice,
+        &author,
         message::SetCheckpoint {
             project_name: project.name,
             org_id: project.org_id,
@@ -269,16 +267,16 @@ async fn set_fork_checkpoint() {
 #[async_std::test]
 async fn set_checkpoint_bad_actor() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
     let project_name = project.clone().name;
 
     let project_hash2 = H256::random();
     let new_checkpoint_id = submit_ok(
         &client,
-        &alice,
+        &author,
         message::CreateCheckpoint {
             project_hash: project_hash2,
             previous_checkpoint_id: Some(project.current_cp),
@@ -291,7 +289,7 @@ async fn set_checkpoint_bad_actor() {
     let bad_actor = key_pair_from_string("BadActor");
     let initial_balance = 1000;
     // The bad actor needs funds to submit transactions.
-    transfer(&client, &alice, bad_actor.public(), initial_balance).await;
+    transfer(&client, &author, bad_actor.public(), initial_balance).await;
 
     let random_fee = random_balance();
     submit_ok_with_fee(

--- a/runtime-tests/tests/org_registration.rs
+++ b/runtime-tests/tests/org_registration.rs
@@ -24,13 +24,13 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn register_org() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
-    let initial_balance = client.free_balance(&alice.public()).await.unwrap();
-    let random_fee = random_balance();
+    let (author, user_id) = key_pair_with_associated_user(&client).await;
 
+    let initial_balance = client.free_balance(&author.public()).await.unwrap();
+    let random_fee = random_balance();
     let register_org_message = random_register_org_message();
     let tx_included =
-        submit_ok_with_fee(&client, &alice, register_org_message.clone(), random_fee).await;
+        submit_ok_with_fee(&client, &author, register_org_message.clone(), random_fee).await;
 
     assert!(tx_included
         .events
@@ -61,13 +61,13 @@ async fn register_org() {
 #[async_std::test]
 async fn register_with_duplicated_org_id() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
     let register_org_message = random_register_org_message();
 
-    let tx_included_once = submit_ok(&client, &alice, register_org_message.clone()).await;
+    let tx_included_once = submit_ok(&client, &author, register_org_message.clone()).await;
     assert_eq!(tx_included_once.result, Ok(()));
 
-    let tx_included_twice = submit_ok(&client, &alice, register_org_message.clone()).await;
+    let tx_included_twice = submit_ok(&client, &author, register_org_message.clone()).await;
     assert_eq!(
         tx_included_twice.result,
         Err(RegistryError::DuplicateOrgId.into())
@@ -77,10 +77,11 @@ async fn register_with_duplicated_org_id() {
 #[async_std::test]
 async fn unregister_org() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
+
     let register_org_message = random_register_org_message();
 
-    let tx_included = submit_ok(&client, &alice, register_org_message.clone()).await;
+    let tx_included = submit_ok(&client, &author, register_org_message.clone()).await;
 
     assert!(tx_included
         .events
@@ -100,14 +101,14 @@ async fn unregister_org() {
         .unwrap()
         .unwrap();
     // The org needs funds to submit transactions.
-    transfer(&client, &alice, org.account_id, initial_balance).await;
+    transfer(&client, &author, org.account_id, initial_balance).await;
 
     let unregister_org_message = message::UnregisterOrg {
         org_id: register_org_message.org_id.clone(),
     };
     let random_fee = random_balance();
     let tx_unregister_applied =
-        submit_ok_with_fee(&client, &alice, unregister_org_message.clone(), random_fee).await;
+        submit_ok_with_fee(&client, &author, unregister_org_message.clone(), random_fee).await;
     assert_eq!(tx_unregister_applied.result, Ok(()));
 
     assert!(
@@ -125,10 +126,10 @@ async fn unregister_org() {
 #[async_std::test]
 async fn unregister_org_bad_actor() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
     let register_org_message = random_register_org_message();
 
-    let tx_included = submit_ok(&client, &alice, register_org_message.clone()).await;
+    let tx_included = submit_ok(&client, &author, register_org_message.clone()).await;
 
     assert!(tx_included
         .events
@@ -144,11 +145,9 @@ async fn unregister_org_bad_actor() {
     let unregister_org_message = message::UnregisterOrg {
         org_id: register_org_message.org_id.clone(),
     };
-    let bad_actor = key_pair_from_string("BadActor");
-    let initial_balance = 1000;
-    // The bad actor needs funds to submit transactions.
-    transfer(&client, &alice, bad_actor.public(), initial_balance).await;
 
+    let (bad_actor, _) = key_pair_with_associated_user(&client).await;
+    let initial_balance = client.free_balance(&bad_actor.public()).await.unwrap();
     let random_fee = random_balance();
     let tx_unregister_applied = submit_ok_with_fee(
         &client,
@@ -176,10 +175,10 @@ async fn unregister_org_bad_actor() {
 #[async_std::test]
 async fn unregister_org_with_projects() {
     let client = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let org_id = random_id();
-    let random_project = create_project_with_checkpoint(org_id.clone(), &client, &alice).await;
+    let random_project = create_project_with_checkpoint(org_id.clone(), &client, &author).await;
 
     assert!(
         org_exists(&client, random_project.org_id.clone()).await,
@@ -198,7 +197,7 @@ async fn unregister_org_with_projects() {
     let unregister_org_message = message::UnregisterOrg {
         org_id: random_project.org_id.clone(),
     };
-    let tx_unregister_applied = submit_ok(&client, &alice, unregister_org_message.clone()).await;
+    let tx_unregister_applied = submit_ok(&client, &author, unregister_org_message.clone()).await;
 
     assert_eq!(
         tx_unregister_applied.result,

--- a/runtime-tests/tests/org_registration.rs
+++ b/runtime-tests/tests/org_registration.rs
@@ -24,7 +24,7 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn register_org() {
     let client = Client::new_emulator();
-    let (author, user_id) = key_pair_with_associated_user(&client).await;
+    let (author, _) = key_pair_with_associated_user(&client).await;
 
     let initial_balance = client.free_balance(&author.public()).await.unwrap();
     let random_fee = random_balance();
@@ -48,11 +48,11 @@ async fn register_org() {
         .unwrap()
         .unwrap();
     assert_eq!(org.id, register_org_message.org_id);
-    assert_eq!(org.members, vec![alice.public()]);
+    assert_eq!(org.members, vec![author.public()]);
     assert!(org.projects.is_empty());
 
     assert_eq!(
-        client.free_balance(&alice.public()).await.unwrap(),
+        client.free_balance(&author.public()).await.unwrap(),
         initial_balance - random_fee,
         "The tx fee was not charged properly."
     );


### PR DESCRIPTION
Backports changes that don’t affect the runtime from #400 to master. This should make it easier to integrate `upstream` with `master`.