### PR TITLE
cli: runtime group with new version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 ### Breaking changes
 
+* cli: Move `update-runtime` to `runtime update`
 * Rename `TransactionApplied` to `TransactionIncluded`
 * cli: Rename the key-pair storage file from 'accounts.json' to 'key-pairs.json'
 * cli: Move key-pair related commands under the new `key-pair` command group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Upcoming
 
 ### Addition
 
+* cli: Add `runtime version` command to check the on-chain runtime version
 * cli: Add `update-runtime` command to update the on-chain runtime
 * cli: Mutually support local account names where only SS58 address were
   supported as params.

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -27,6 +27,7 @@ pub mod key_pair;
 pub mod org;
 pub mod other;
 pub mod project;
+pub mod runtime;
 pub mod user;
 
 fn parse_account_id(data: &str) -> Result<AccountId, String> {

--- a/cli/src/command/other.rs
+++ b/cli/src/command/other.rs
@@ -23,13 +23,6 @@ use super::*;
 pub enum Command {
     /// Show the genesis hash the node uses
     GenesisHash(ShowGenesisHash),
-
-    /// Submit a transaction to update the on-chain runtime.
-    /// Requirements:
-    ///   * the tx author must be the chain's sudo key
-    ///   * the `spec_version` of the given wasm runtime must be greater than the chain runtime's.
-    ///   * the `spec_name` must match between the wasm runtime and the chain runtime.
-    UpdateRuntime(UpdateRuntime),
 }
 
 #[async_trait::async_trait]
@@ -37,7 +30,6 @@ impl CommandT for Command {
     async fn run(self) -> Result<(), CommandError> {
         match self {
             Command::GenesisHash(cmd) => cmd.run().await,
-            Command::UpdateRuntime(cmd) => cmd.run().await,
         }
     }
 }
@@ -54,42 +46,6 @@ impl CommandT for ShowGenesisHash {
         let client = self.network_options.client().await?;
         let genesis_hash = client.genesis_hash();
         println!("Genesis block hash: 0x{}", hex::encode(genesis_hash));
-        Ok(())
-    }
-}
-
-#[derive(StructOpt, Clone)]
-pub struct UpdateRuntime {
-    /// The path to the (wasm) runtime code to submit
-    path: std::path::PathBuf,
-
-    #[structopt(flatten)]
-    network_options: NetworkOptions,
-
-    #[structopt(flatten)]
-    tx_options: TxOptions,
-}
-
-#[async_trait::async_trait]
-impl CommandT for UpdateRuntime {
-    async fn run(self) -> Result<(), CommandError> {
-        let client = self.network_options.client().await?;
-        let new_runtime_code =
-            std::fs::read(self.path).expect("Invalid path or couldn't read the wasm file");
-
-        let update_runtime_fut = client
-            .sign_and_submit_message(
-                &self.tx_options.author,
-                message::UpdateRuntime {
-                    code: new_runtime_code,
-                },
-                self.tx_options.fee,
-            )
-            .await?;
-        announce_tx("Submitting the new on-chain runtime...");
-
-        update_runtime_fut.await?.result?;
-        println!("✓ The new on-chain runtime is now published.");
         Ok(())
     }
 }

--- a/cli/src/command/runtime.rs
+++ b/cli/src/command/runtime.rs
@@ -1,0 +1,74 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Define the commands supported by the CLI related to the on-chain runtime.
+
+use super::*;
+
+/// Project related commands
+#[derive(StructOpt, Clone)]
+pub enum Command {
+    /// Submit a transaction to update the on-chain runtime.
+    /// Requirements:
+    ///   * the tx author must be the chain's sudo key
+    ///   * the `spec_version` of the given wasm runtime must be greater than the chain runtime's.
+    ///   * the `spec_name` must match between the wasm runtime and the chain runtime.
+    Update(Update),
+}
+
+#[async_trait::async_trait]
+impl CommandT for Command {
+    async fn run(self) -> Result<(), CommandError> {
+        match self {
+            Command::Update(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Clone)]
+pub struct Update {
+    /// The path to the (wasm) runtime code to submit
+    path: std::path::PathBuf,
+
+    #[structopt(flatten)]
+    network_options: NetworkOptions,
+
+    #[structopt(flatten)]
+    tx_options: TxOptions,
+}
+
+#[async_trait::async_trait]
+impl CommandT for Update {
+    async fn run(self) -> Result<(), CommandError> {
+        let client = self.network_options.client().await?;
+        let new_runtime_code =
+            std::fs::read(self.path).expect("Invalid path or couldn't read the wasm file");
+
+        let update_runtime_fut = client
+            .sign_and_submit_message(
+                &self.tx_options.author,
+                message::UpdateRuntime {
+                    code: new_runtime_code,
+                },
+                self.tx_options.fee,
+            )
+            .await?;
+        announce_tx("Submitting the new on-chain runtime...");
+
+        update_runtime_fut.await?.result?;
+        println!("✓ The new on-chain runtime is now published.");
+        Ok(())
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,7 +25,7 @@ use thiserror::Error as ThisError;
 pub mod key_pair_storage;
 
 mod command;
-use command::{account, key_pair, org, other, project, user};
+use command::{account, key_pair, org, other, project, runtime, user};
 
 /// The type that captures the command line.
 #[derive(StructOpt, Clone)]
@@ -107,6 +107,7 @@ pub enum Command {
     KeyPair(key_pair::Command),
     Org(org::Command),
     Project(project::Command),
+    Runtime(runtime::Command),
     User(user::Command),
 
     #[structopt(flatten)]
@@ -122,6 +123,7 @@ impl CommandT for Command {
             Command::Org(cmd) => cmd.run().await,
             Command::Project(cmd) => cmd.run().await,
             Command::User(cmd) => cmd.run().await,
+            Command::Runtime(cmd) => cmd.run().await,
             Command::Other(cmd) => cmd.run().await,
         }
     }

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -23,7 +23,8 @@ use sp_runtime::{traits::Hash as _, BuildStorage as _, Digest};
 use sp_state_machine::backend::Backend as _;
 
 use radicle_registry_runtime::{
-    registry, runtime_api, AccountId, BalancesConfig, GenesisConfig, Hash, Hashing, Header, Runtime,
+    registry, runtime_api, AccountId, BalancesConfig, GenesisConfig, Hash, Hashing, Header,
+    Runtime, RuntimeVersion,
 };
 
 use crate::backend;
@@ -196,6 +197,10 @@ impl backend::Backend for Emulator {
 
     fn get_genesis_hash(&self) -> Hash {
         self.genesis_hash
+    }
+
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        panic!("Not implemented");
     }
 }
 

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -16,7 +16,7 @@
 //! Define trait for client backends and provide emulator and remote node implementation
 use futures::future::BoxFuture;
 
-pub use radicle_registry_runtime::{Hash, Header, UncheckedExtrinsic};
+pub use radicle_registry_runtime::{Hash, Header, RuntimeVersion, UncheckedExtrinsic};
 
 use crate::interface::*;
 
@@ -72,4 +72,7 @@ pub trait Backend {
 
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;
+
+    /// Get the on-chain runtime version.
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
 }

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -212,6 +212,15 @@ impl backend::Backend for RemoteNode {
     fn get_genesis_hash(&self) -> Hash {
         self.genesis_hash
     }
+
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        self.rpc
+            .state
+            .runtime_version(None)
+            .compat()
+            .await
+            .map_err(Into::into)
+    }
 }
 
 /// Return all the events belonging to the transaction included in the given block.

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -96,4 +96,8 @@ impl backend::Backend for RemoteNodeWithExecutor {
     fn get_genesis_hash(&self) -> Hash {
         self.backend.get_genesis_hash()
     }
+
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        self.backend.onchain_runtime_version().await
+    }
 }

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -21,7 +21,7 @@ use futures::future::BoxFuture;
 
 pub use radicle_registry_core::*;
 
-pub use radicle_registry_runtime::{BlockNumber, Hash, Header};
+pub use radicle_registry_runtime::{BlockNumber, Hash, Header, RuntimeVersion};
 
 pub use radicle_registry_runtime::{registry::Event as RegistryEvent, Balance, Event};
 pub use sp_core::crypto::{Pair as CryptoPair, Public as CryptoPublic};
@@ -143,4 +143,6 @@ pub trait ClientT {
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error>;
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Option<state::Checkpoint>, Error>;
+
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -305,6 +305,10 @@ impl ClientT for Client {
         self.fetch_map_value::<registry::store::Checkpoints, _, _>(id)
             .await
     }
+
+    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        self.backend.onchain_runtime_version().await
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,7 +34,7 @@ use sp_core::ed25519;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
 use sp_runtime::{create_runtime_str, generic, Perbill};
 use sp_std::prelude::*;
-use sp_version::RuntimeVersion;
+pub use sp_version::RuntimeVersion;
 
 pub mod fees;
 pub mod registry;


### PR DESCRIPTION
Motivated by the need to check the on-chain runtime version.

### Changes

* cli: Move 'update-runtime' to 'update runtime'
    _Only moved the command, nothing new here._

* cli: Add 'runtime version' command

