### PR TITLE
Ensure build-runtime-wasm always produces artifact

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -5,6 +5,10 @@ use substrate_wasm_builder_runner::WasmBuilder;
 const BUILD_WASM_BINARY_OUR_DIR_ENV: &str = "BUILD_WASM_BINARY_OUT_DIR";
 
 fn main() {
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        BUILD_WASM_BINARY_OUR_DIR_ENV
+    );
     if let Some(wasm_binary_dir) = env::var_os(BUILD_WASM_BINARY_OUR_DIR_ENV) {
         build_wasm_runtime_in_dir(&wasm_binary_dir);
     }

--- a/scripts/build-runtime-wasm
+++ b/scripts/build-runtime-wasm
@@ -2,13 +2,12 @@
 
 set -euo pipefail
 
-if [ $# -ne 1 ] || [ $1 = --help ] ; then
+if [ $# -ne 1 ] || [ "$1" = --help ] ; then
   echo "Usage: $0 <wasm_binary_output>"
   exit 1
 fi
 
-export BUILD_WASM_BINARY_OUT_DIR=$(mktemp -d)
+export BUILD_WASM_BINARY_OUT_DIR="$(mktemp -d)"
 cargo build -p radicle-registry-runtime --release
-mkdir -p $(dirname $1)
-mv $BUILD_WASM_BINARY_OUT_DIR/* $1
-rm -r $BUILD_WASM_BINARY_OUT_DIR
+mv "$BUILD_WASM_BINARY_OUT_DIR/radicle_registry_runtime.wasm" "$1"
+rm -r "$BUILD_WASM_BINARY_OUT_DIR"


### PR DESCRIPTION
Fixes #469

We also improve the shell script by eliminating lints and redundant commands.