### PR TITLE
Decouple telemetry config from chain spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -45,12 +45,12 @@ pub enum Chain {
 }
 
 impl Chain {
-    pub fn spec(&self, enable_telemetry: bool) -> ChainSpec {
+    pub fn spec(&self) -> ChainSpec {
         match self {
             Chain::Dev => dev(),
             Chain::LocalDevnet => local_devnet(),
             Chain::Devnet => devnet(),
-            Chain::Ffnet => ffnet(enable_telemetry),
+            Chain::Ffnet => ffnet(),
         }
     }
 }
@@ -89,7 +89,10 @@ fn devnet() -> ChainSpec {
     )
 }
 
-fn ffnet(enable_telemetry: bool) -> ChainSpec {
+fn ffnet() -> ChainSpec {
+    let telemetry_endpoints =
+        TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".to_string(), 0)])
+            .unwrap();
     GenericChainSpec::from_genesis(
         "Radicle Registry ffnet",
         "ffnet",
@@ -102,7 +105,7 @@ fn ffnet(enable_telemetry: bool) -> ChainSpec {
             "/dns4/boot-1.ff.radicle.network./tcp/30333/p2p/QmceS5WYfDyKNtnzrxCw4TEL9nokvJkRi941oUzBvErsuD"
                 .parse().unwrap()
         ],
-        polkadot_telemetry(enable_telemetry),
+        Some(telemetry_endpoints),
         Some("ffnet"), // protocol_id
         Some(sc_service::Properties::try_from(PowAlgConfig::Blake3).unwrap()),
         None, // no extensions
@@ -178,15 +181,4 @@ fn account_id(seed: &str) -> AccountId {
     <AccountId as CryptoType>::Pair::from_string(&format!("//{}", seed), None)
         .expect("Parsing the account key pair seed failed")
         .public()
-}
-
-fn polkadot_telemetry(enable: bool) -> Option<TelemetryEndpoints> {
-    if enable {
-        Some(
-            TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".to_string(), 0)])
-                .unwrap(),
-        )
-    } else {
-        None
-    }
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -125,7 +125,7 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
-        let chain_spec = parse_chain(id)?.spec(!self.no_telemetry);
+        let chain_spec = parse_chain(id)?.spec();
         Ok(Box::new(chain_spec) as Box<dyn ChainSpec>)
     }
 }
@@ -148,6 +148,7 @@ impl Cli {
     fn create_run_cmd(&self) -> RunCmd {
         // This does not panic if there are no required arguments which we statically know.
         let mut run_cmd = RunCmd::from_iter_safe(vec![] as Vec<String>).unwrap();
+        run_cmd.no_telemetry = self.no_telemetry;
         run_cmd.shared_params.chain = Some(self.chain.clone());
         run_cmd.network_params.bootnodes = self.bootnodes.clone();
         run_cmd.network_params.node_key_params.node_key = self.node_key.clone();


### PR DESCRIPTION
We leverage `RunCmd::no_telemetry` to decouple the telemetry configuration from the chain spec.