### PR TITLE
Fix CLI runtime command help

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -165,8 +165,15 @@ For semantic updates to take effect on an existing chain they need to be
 deployed to the chain.
 
 ```
-radicle-registry-cli update-runtime ./runtime/latest.wasm --author <sudo_key> --node-host <node_host>
+radicle-registry-cli runtime update ./runtime/latest.wasm --author <sudo_key>
 ```
+
+The author key must be the sudo key configured in the chain specification for
+the chain that is updated.
+
+For the runtime update transaction to be accepted the `spec_version` of the
+submitted runtime must be greater than the `spec_version` of the on-chain
+runtime.
 
 Changes to the chain state must be backwards-compatibility, requiring particular
 attention. A policy and process for such updates have not been established yet.

--- a/cli/src/command/runtime.rs
+++ b/cli/src/command/runtime.rs
@@ -17,14 +17,10 @@
 
 use super::*;
 
-/// Project related commands
+/// Runtime related commands
 #[derive(StructOpt, Clone)]
 pub enum Command {
     /// Submit a transaction to update the on-chain runtime.
-    /// Requirements:
-    ///   * the tx author must be the chain's sudo key
-    ///   * the `spec_version` of the given wasm runtime must be greater than the chain runtime's.
-    ///   * the `spec_name` must match between the wasm runtime and the chain runtime.
     Update(Update),
 
     /// Show the version of the on-chain runtime.
@@ -91,9 +87,6 @@ impl CommandT for ShowVersion {
         println!("On-chain runtime version:");
         println!("  spec_version: {}", v.spec_version);
         println!("  impl_version: {}", v.impl_version);
-        println!("  authoring_version: {}", v.authoring_version);
-        println!("  spec_name: {}", v.spec_name);
-        println!("  impl_name: {}", v.impl_name);
         Ok(())
     }
 }


### PR DESCRIPTION
* Fix the description of the runtime group
* Move details about the update from the command help (which was not properly formatted with regards to newlines) to the developer docs.
* Don’t print irrelevant version information.