### PR TITLE
client: Provide naive deposit_costs method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Upcoming
 
 ### Addition
 
+* client: Add `deposit_costs` method
 * Support user project registration
 * cli: Add `runtime version` command to check the on-chain runtime version
 * cli: Add `update-runtime` command to update the on-chain runtime

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -145,4 +145,7 @@ pub trait ClientT {
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Option<state::Checkpoint>, Error>;
 
     async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
+
+    /// Get the deposit costs associated with a given Message.
+    fn deposit_costs(message: impl Message) -> Balance;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -313,6 +313,10 @@ impl ClientT for Client {
     async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
         self.backend.onchain_runtime_version().await
     }
+
+    fn deposit_costs(message: impl Message) -> Balance {
+        radicle_registry_runtime::deposit_costs(&message.into_runtime_call())
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::registry::{org_has_member_with_account, store};
-use crate::{AccountId, Call, DispatchError, Runtime};
+use crate::{AccountId, Call, DispatchError, RegistryCall};
 use radicle_registry_core::*;
 
 use frame_support::storage::{StorageMap as _, StorageValue as _};
@@ -22,8 +22,6 @@ use frame_support::traits::{Currency, ExistenceRequirement, Imbalance, WithdrawR
 use sp_runtime::Permill;
 
 type NegativeImbalance = <crate::Balances as Currency<AccountId>>::NegativeImbalance;
-
-type RegistryCall = crate::registry::Call<Runtime>;
 
 /// Share of a transaction fee that is burned rather than credited to the block author.
 const BURN_SHARE: Permill = Permill::from_percent(1);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,6 +45,8 @@ pub use pallet_balances as balances;
 pub use radicle_registry_core::*;
 pub use runtime_api::{api, RuntimeApi};
 
+pub type RegistryCall = registry::Call<Runtime>;
+
 /// An index to a block.
 pub type BlockNumber = u32;
 
@@ -202,3 +204,17 @@ construct_runtime!(
                 Registry: registry::{Module, Call, Storage, Event, Inherent},
         }
 );
+
+/// Get the deposit costs associated with a given call.
+pub fn deposit_costs(call: &Call) -> Balance {
+    match call {
+        Call::Registry(registry_call) => match registry_call {
+            RegistryCall::register_project(_)
+            | RegistryCall::register_member(_)
+            | RegistryCall::register_user(_)
+            | RegistryCall::register_org(_) => 10,
+            _ => 0,
+        },
+        _ => 0,
+    }
+}


### PR DESCRIPTION
Closes #485 

This allows the upstream to get the deposit costs associated with a
given Message. It is a naive implementation to allow the upstream to
move forward with a real API and it will be followed up by me in the
coming week, where tx deposits will be implemented.