### PR TITLE
Refactor deposit costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 ### Breaking changes
 
+* client: Move deposit costs into constants for better ergonomics
 * client: Use `ProjectDomain::Org(id)` istead of just `id` on project-related references
 * Only unregistered a user if not a member of any org
 * Tx author needs to have an associated registered user to operate on Orgs
@@ -58,7 +59,6 @@ Upcoming
 
 ### Addition
 
-* client: Add `deposit_costs` method
 * Support user project registration
 * cli: Add `runtime version` command to check the on-chain runtime version
 * cli: Add `update-runtime` command to update the on-chain runtime

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -145,7 +145,4 @@ pub trait ClientT {
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Option<state::Checkpoint>, Error>;
 
     async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
-
-    /// Get the deposit costs associated with a given Message.
-    fn deposit_costs(message: impl Message) -> Balance;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -48,6 +48,9 @@ mod transaction;
 pub use crate::interface::*;
 pub use radicle_registry_core::Balance;
 pub use radicle_registry_runtime::fees::MINIMUM_FEE;
+pub use radicle_registry_runtime::registry::{
+    REGISTER_MEMBER_DEPOSIT, REGISTER_ORG_DEPOSIT, REGISTER_PROJECT_DEPOSIT, REGISTER_USER_DEPOSIT,
+};
 
 pub use backend::{EmulatorControl, EMULATOR_BLOCK_AUTHOR};
 
@@ -312,10 +315,6 @@ impl ClientT for Client {
 
     async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
         self.backend.onchain_runtime_version().await
-    }
-
-    fn deposit_costs(message: impl Message) -> Balance {
-        radicle_registry_runtime::deposit_costs(&message.into_runtime_call())
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -204,17 +204,3 @@ construct_runtime!(
                 Registry: registry::{Module, Call, Storage, Event, Inherent},
         }
 );
-
-/// Get the deposit costs associated with a given call.
-pub fn deposit_costs(call: &Call) -> Balance {
-    match call {
-        Call::Registry(registry_call) => match registry_call {
-            RegistryCall::register_project(_)
-            | RegistryCall::register_member(_)
-            | RegistryCall::register_user(_)
-            | RegistryCall::register_org(_) => 10,
-            _ => 0,
-        },
-        _ => 0,
-    }
-}

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -63,6 +63,17 @@ where
 /// Funds that are credited to the block author for every block.
 pub const BLOCK_REWARD: Balance = 1000;
 
+// Placeholder data to be exported by the client so we can implement the UI in
+// Upstream.
+/// Deposit for registering a user.
+pub const REGISTER_USER_DEPOSIT: Balance = 10;
+/// Deposit for registering a project.
+pub const REGISTER_PROJECT_DEPOSIT: Balance = 10;
+/// Deposit for registering an org.
+pub const REGISTER_ORG_DEPOSIT: Balance = 10;
+/// Deposit for registering a member on an org.
+pub const REGISTER_MEMBER_DEPOSIT: Balance = 10;
+
 pub mod store {
     use super::*;
 


### PR DESCRIPTION
The `deposit_costs` method was cumbersome to use because we had to construct a message to just get to a constant.