### PR TITLE
Version Orgs state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 ### Breaking changes
 
+* runtime: abandon `Orgs` storage in favor of `Orgs1`
 * runtime: We introduce the `CheckVersion` transaction validation that requires
   authors to include the runtime version in the transaction.
 * cli: `project register` now also expects domain type

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -43,6 +43,39 @@ pub type TxHash = Hash;
 #[doc(inline)]
 pub type BlockHeader = Header;
 
+/// Org
+///
+/// Different from [state::OrgV1] in which this type gathers
+/// both the [`Id`] and the other [`Org`] fields, respectively stored
+/// as an Org's storage key and data, into one complete type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Org {
+    // Unique id of an Org.
+    pub id: Id,
+
+    /// See [state::OrgV1::account_id]
+    pub account_id: AccountId,
+
+    /// See [state::OrgV1::members]
+    pub members: Vec<Id>,
+
+    /// See [state::OrgV1::projects]
+    pub projects: Vec<ProjectName>,
+}
+
+impl Org {
+    pub fn new(id: Id, org: state::Orgs1Data) -> Org {
+        match org {
+            state::Orgs1Data::V1(org) => Org {
+                id,
+                account_id: org.account_id,
+                members: org.members,
+                projects: org.projects,
+            },
+        }
+    }
+}
+
 /// Result of a transaction being included in a block.
 ///
 /// Returned after submitting an transaction to the blockchain.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -247,17 +247,17 @@ impl ClientT for Client {
     }
 
     async fn get_org(&self, id: Id) -> Result<Option<Org>, Error> {
-        self.fetch_map_value::<registry::store::Orgs, _, _>(id.clone())
+        self.fetch_map_value::<registry::store::Orgs1, _, _>(id.clone())
             .await
-            .map(|maybe_org: Option<state::Org>| maybe_org.map(|org| Org::new(id, org)))
+            .map(|maybe_org: Option<state::Orgs1Data>| maybe_org.map(|org| Org::new(id, org)))
     }
 
     async fn list_orgs(&self) -> Result<Vec<Id>, Error> {
-        let orgs_prefix = registry::store::Orgs::final_prefix();
+        let orgs_prefix = registry::store::Orgs1::final_prefix();
         let keys = self.backend.fetch_keys(&orgs_prefix, None).await?;
         let mut org_ids: Vec<Id> = Vec::with_capacity(keys.len());
         for key in keys {
-            let org_id = registry::store::Orgs::decode_key(&key)
+            let org_id = registry::store::Orgs1::decode_key(&key)
                 .expect("Invalid runtime state key. Cannot extract org ID");
             org_ids.push(org_id)
         }

--- a/core/README.md
+++ b/core/README.md
@@ -46,21 +46,59 @@ For each entity version the documentation has the following sections
 
 To make the runtime state backwards compatible, every state entity that is added
 must be versioned using the following schema.
+Please follow the naming convention introduced in the examples as closely as possible.
+
+The storage defines the structure of the data.
+If it's altered, e.g. a key type is changed or it's converting from a map to a list,
+a new version must be added.
+The storage must include its version in its name:
+
+```rust
+// registry.rs
+
+pub mod store {
+    ...
+      decl_storage! {
+          ...
+              pub Users1: map hasher(blake2_128_concat) Id => Option<state::Users1Data>;
+              pub Users2: map hasher(blake2_128_concat) NewId => Option<state::Users2Data>;
+```
+
+The stored data must be an enum capable of containing different data versions.
+It must be versioned consistently and independently of the storage version:
 
 ```rust
 // state.rs
 
-pub enum User {
-  UserV1(UserV1)
-  UserV2(UserV1)
+pub enum Users1Data {
+    V1(UserV1)
+    V2(UserV2)
 }
+
+pub enum Users2Data {
+    V3(UserId)
+    V4(UserV4)
+}
+```
+
+If the stored data is a specialized data structure,
+it must be versioned same as the stored data, which contains it:
+
+```rust
+// state.rs
 
 pub struct UserV1 {
-  // ...fields
+    ...
 }
 
-pub struct UserV2 {
-  // ... changed fields
+pub enum UserV2 {
+    ...
+}
+
+// UserId is general purpose
+
+pub struct UserV4 {
+    ...
 }
 ```
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -74,37 +74,6 @@ impl std::fmt::Display for ProjectDomain {
     }
 }
 
-/// Org
-///
-/// Different from [state::Org] in which this type gathers
-/// both the [`Id`] and the other [`Org`] fields, respectively stored
-/// as an Org's storage key and data, into one complete type.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Org {
-    // Unique id of an Org.
-    pub id: Id,
-
-    /// See [state::Org::account_id]
-    pub account_id: AccountId,
-
-    /// See [state::Org::members]
-    pub members: Vec<Id>,
-
-    /// See [state::Org::projects]
-    pub projects: Vec<ProjectName>,
-}
-
-impl Org {
-    pub fn new(id: Id, org: state::Org) -> Org {
-        Org {
-            id,
-            account_id: org.account_id,
-            members: org.members,
-            projects: org.projects,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Project {
     /// The name of the project, unique within its org.

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -26,12 +26,12 @@ use parity_scale_codec::{Decode, Encode};
 ///
 /// # State changes
 ///
-/// If successful, a new [crate::state::Org] with the given properties is added to the state.
+/// If successful, a new [crate::state::Orgs1Data] with the given properties is added to the state.
 ///
-/// [crate::state::Org::members] is initialized with the user id associated with the author
+/// [crate::state::Orgs1Data::members] is initialized with the user id associated with the author
 /// as the only member.
 ///
-/// [crate::state::Org::account_id] is generated randomly.
+/// [crate::state::Orgs1Data::account_id] is generated randomly.
 ///
 /// # State-dependent validations
 ///
@@ -97,7 +97,7 @@ pub struct UnregisterUser {
 ///
 /// # State changes
 ///
-/// If successful, the `user_id` is added to [crate::state::Org::members] of `org_id` .
+/// If successful, the `user_id` is added to [crate::state::Orgs1Data::members] of `org_id` .
 ///
 /// # State-dependent validations
 ///
@@ -197,7 +197,7 @@ pub struct SetCheckpoint {
 ///
 /// If successful, `value` is deducated from the org account and
 /// added to the the recipient account. The org account is given
-/// by [crate::state::Org::account_id] of the given org.
+/// by [crate::state::Orgs1Data::account_id] of the given org.
 ///
 /// If the recipient account did not exist before, it is created.
 /// The recipient account may be a user account or an org account.

--- a/runtime/src/fees/payment.rs
+++ b/runtime/src/fees/payment.rs
@@ -97,10 +97,10 @@ fn payer_account(author: AccountId, call: &Call) -> AccountId {
 /// When the User associated with `author` is a member of the org
 /// identified by `org_id`, return that org's account, otherwise the author's.
 fn org_payer_account(author: AccountId, org_id: &Id) -> AccountId {
-    match store::Orgs::get(org_id) {
+    match store::Orgs1::get(org_id) {
         Some(org) => {
             if org_has_member_with_account(&org, author) {
-                org.account_id
+                org.account_id()
             } else {
                 author
             }


### PR DESCRIPTION
Part of https://github.com/radicle-dev/radicle-registry/issues/496. ~Blocked by https://github.com/radicle-dev/radicle-registry/pull/514.~

This PR introduces few changes:
- Update state versioning guide
- Drop `Orgs` storage in favor of `OrgsV1`. It allows further versioning of the storage itself by introducing `OrgsV2` (e.g. to change the key type).
- Rename `state::Org` to `state::OrgV1` and introduce versioning enum `state::Org`. `Org`'s API reflects `OrgV1`'s for ease of use. This API is expected to change in the future, e.g. addition of `OrgV2` may or may not alter it, we don't know that yet.
- Move `core::Org` to `client::interface`. This struct is used only in the client's API, so that's a better place for it. It lets the client make decision about what it exposes without touching the runtime. This change is invisible to the client consumers, neither the structure nor its import path changes.