### PR TITLE
Node binary prints version and commit hash

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -111,10 +111,10 @@ To create a release from the current master branch run `./scripts/create-release
 
 ### Tags
 
-Our tags are composed of the release date followed by a number representing the
-number of releases done in that same date. For example, `2020-04-09-0` would
-be the first release done that day. Should we need to make a new release in
-that same day, it'd be tagged `2020-04-09-1`.
+Our tags are composed of the release date followed by an optional number representing the
+number of releases done in that same date. For example, `2020.04.09` would be
+the first release done that day. Should we need to make a new release in that
+same day, it'd be tagged `2020.04.09-1`.
 
 
 Local devnet

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,5 +1,5 @@
 use vergen::{generate_cargo_keys, ConstantsFlags};
 
 fn main() {
-    generate_cargo_keys(ConstantsFlags::SHA_SHORT).unwrap();
+    generate_cargo_keys(ConstantsFlags::all()).unwrap();
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -101,7 +101,8 @@ impl SubstrateCli for Cli {
     }
 
     fn impl_version() -> &'static str {
-        "ff.0"
+        // uses `git describe`
+        env!("VERGEN_SEMVER")
     }
 
     fn description() -> &'static str {

--- a/scripts/create-release
+++ b/scripts/create-release
@@ -22,14 +22,16 @@ artifacts_dir=$(mktemp -d)
   curl -sSLO "$base_url/radicle-registry-node.tar.gz"
 )
 
+release_name="$(date +%Y.%m.%d)"
 declare -i release_counter=0
+
 while true; do
-  release_name="$(date +%Y-%m-%d)-$release_counter"
   if [[ $(git tag -l "$release_name" | wc -l) -eq 0 ]]; then
     break
   fi
   echo "Tag $release_name already exists"
   release_counter+=1
+  release_name="$(date +%Y.%m.%d)-$release_counter"
 done
 
 echo "Creating and pushing tag"


### PR DESCRIPTION
The version identifier that the node binary prints is now generated from `git describe`. This allows us to easily identify node versions.

Moreover we adjust the tagging/versioning scheme by replacing dashes in the date with dots and removing the trailing zero for the first release. For example `2020.06.12` instead of `2020-06-12-0`. This leads to more readable `git describe` output. For example `2020.06.09-13-g8ac2839` instead of `2020-06-09-0-13-g8ac2839`.