### PR TITLE
Use VERGEN_SEMVER for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "url 1.7.2",
+ "vergen",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,3 +31,6 @@ url = "1.7"
 [dependencies.sp-core]
 git = "https://github.com/paritytech/substrate"
 rev = "6dc23feece77d758656651e04de964d72e9b5d34"
+
+[build-dependencies]
+vergen = "3"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,5 @@
+use vergen::{generate_cargo_keys, ConstantsFlags};
+
+fn main() {
+    generate_cargo_keys(ConstantsFlags::all()).unwrap();
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -29,7 +29,10 @@ use command::{account, key_pair, org, other, project, runtime, user};
 
 /// The type that captures the command line.
 #[derive(StructOpt, Clone)]
-#[structopt(max_term_width = 80)]
+#[structopt(
+    max_term_width = 80,
+    version = env!("VERGEN_SEMVER"),
+)]
 pub struct CommandLine {
     #[structopt(subcommand)]
     pub command: Command,


### PR DESCRIPTION
Similar to #516. We make the CLI print the version derived from `git describe` at build time.example `2020.06.09-13-g8ac2839` instead of `2020-06-09-0-13-g8ac2839`.