### PR TITLE
Expose the SecretStringError type as CryptoError

### DIFF
--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -24,7 +24,9 @@ pub use radicle_registry_core::*;
 pub use radicle_registry_runtime::{BlockNumber, Hash, Header, RuntimeVersion};
 
 pub use radicle_registry_runtime::{registry::Event as RegistryEvent, Balance, Event};
-pub use sp_core::crypto::{Pair as CryptoPair, Public as CryptoPublic};
+pub use sp_core::crypto::{
+    Pair as CryptoPair, Public as CryptoPublic, SecretStringError as CryptoError,
+};
 pub use sp_core::{ed25519, H256};
 
 pub use crate::error::Error;


### PR DESCRIPTION
So that downstream users of the trait can also refer to the error.

Basically, I need access to the trait for the key storage, but I have no way of referring to the error unless I also add sp-core as a dep to proxy.