### PR TITLE
Fail when creating a release and artifacts are missing 

### DIFF
--- a/scripts/create-release
+++ b/scripts/create-release
@@ -18,8 +18,9 @@ base_url="https://builds.radicle.xyz/radicle-registry/master/$commit/artifacts"
 artifacts_dir=$(mktemp -d)
 (
   cd "$artifacts_dir"
-  curl -sSLO "$base_url/radicle-registry-cli.tar.gz"
-  curl -sSLO "$base_url/radicle-registry-node.tar.gz"
+  curl -sfSLO "$base_url/radicle-registry-cli.tar.gz"
+  curl -sfSLO "$base_url/radicle-registry-node.tar.gz"
+  curl -sfSLO "$base_url/runtime.wasm"
 )
 
 release_name="$(date +%Y.%m.%d)"


### PR DESCRIPTION
We enforce that the version of the `runtime` crate matches the runtime version. This allows us to reference different runtime versions via Cargo and allows us to extract and use the runtime version in builds to upload artifacts.