### PR TITLE
Drop "onchain" from runtime version API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* client: Renamed `ClientT::onchain_runtime_version` to
+  `ClientT::runtime_version`.
 * client: `ClientT::get_checkpoint` returns a new `Checkpoint` structure
 * runtime: abandon `Checkpoints` storage in favor of `Checkpoints1`
 * runtime: abandon `InitialCheckpoints` storage in favor of `InitialCheckpoints1`

--- a/cli/src/command/runtime.rs
+++ b/cli/src/command/runtime.rs
@@ -83,7 +83,7 @@ pub struct ShowVersion {
 impl CommandT for ShowVersion {
     async fn run(self) -> Result<(), CommandError> {
         let client = self.network_options.client().await?;
-        let v = client.onchain_runtime_version().await?;
+        let v = client.runtime_version().await?;
         println!("On-chain runtime version:");
         println!("  spec_version: {}", v.spec_version);
         println!("  impl_version: {}", v.impl_version);

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -239,8 +239,8 @@ impl backend::Backend for Emulator {
         self.genesis_hash
     }
 
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
-        panic!("Not implemented");
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        Ok(radicle_registry_runtime::VERSION)
     }
 }
 

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -73,6 +73,6 @@ pub trait Backend {
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;
 
-    /// Get the on-chain runtime version.
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
+    /// Get the runtime version at the latest block
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error>;
 }

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -215,20 +215,20 @@ impl backend::Backend for RemoteNode {
         self.genesis_hash
     }
 
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
-        onchain_runtime_version(&self.rpc).await
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        runtime_version(&self.rpc).await
     }
 }
 
 async fn check_runtime_version(rpc: &Rpc) -> Result<(), Error> {
     const NATIVE: u32 = radicle_registry_runtime::VERSION.spec_version;
-    match onchain_runtime_version(rpc).await?.spec_version {
+    match runtime_version(rpc).await?.spec_version {
         NATIVE => Ok(()),
         other => Err(Error::IncompatibleRuntimeVersion(other)),
     }
 }
 
-async fn onchain_runtime_version(rpc: &Rpc) -> Result<RuntimeVersion, Error> {
+async fn runtime_version(rpc: &Rpc) -> Result<RuntimeVersion, Error> {
     rpc.state
         .runtime_version(None)
         .compat()

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -97,7 +97,7 @@ impl backend::Backend for RemoteNodeWithExecutor {
         self.backend.get_genesis_hash()
     }
 
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
-        self.backend.onchain_runtime_version().await
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        self.backend.runtime_version().await
     }
 }

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -248,6 +248,9 @@ pub trait ClientT {
     /// Return the gensis hash of the chain we are communicating with.
     fn genesis_hash(&self) -> Hash;
 
+    /// Get the runtime version at the latest block
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error>;
+
     async fn free_balance(&self, account_id: &AccountId) -> Result<Balance, Error>;
 
     async fn get_org(&self, org_id: Id) -> Result<Option<Org>, Error>;
@@ -267,6 +270,4 @@ pub trait ClientT {
     async fn list_projects(&self) -> Result<Vec<ProjectId>, Error>;
 
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<Option<Checkpoint>, Error>;
-
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error>;
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -314,8 +314,8 @@ impl ClientT for Client {
             .map(|cp_opt| cp_opt.map(Checkpoint::new))
     }
 
-    async fn onchain_runtime_version(&self) -> Result<RuntimeVersion, Error> {
-        self.backend.onchain_runtime_version().await
+    async fn runtime_version(&self) -> Result<RuntimeVersion, Error> {
+        self.backend.runtime_version().await
     }
 }
 


### PR DESCRIPTION
The client only deals with things that are on chain—there are no other runtimes. To avoid confusion about “non-onchain runtimes” we drop the `onchain` prefix.

We also implement it properly for the emulator.