### PR TITLE
Remove events from client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Upcoming
 ### Breaking changes
 
 * runtime: Tx author pays for `UnregisterOrg`
+* client: Remove `TransactionIncluded::events` field.
 * client: Offline transaction signing now requires users to manually specify the
   runtime spec version the transaction is valid for.
 * client: Renamed `ClientT::onchain_runtime_version` to

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -175,8 +175,6 @@ pub struct TransactionIncluded<Message_: Message> {
     pub tx_hash: TxHash,
     /// The hash of the block the transaction is included in.
     pub block: Hash,
-    /// Events emitted by this transaction
-    pub events: Vec<Event>,
     /// The result of the runtime message.
     ///
     /// See [Message::result_from_events].

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -169,11 +169,10 @@ impl ClientT for Client {
             let events = tx_included.events;
             let tx_hash = tx_included.tx_hash;
             let block = tx_included.block;
-            let result = Message_::result_from_events(events.clone())?;
+            let result = Message_::result_from_events(events)?;
             Ok(TransactionIncluded {
                 tx_hash,
                 block,
-                events,
                 result,
             })
         }))
@@ -201,20 +200,7 @@ impl ClientT for Client {
                 runtime_spec_version,
             },
         );
-        let tx_included_fut = client.submit_transaction(transaction).await?;
-        Ok(Box::pin(async move {
-            let tx_included = tx_included_fut.await?;
-            let events = tx_included.events;
-            let tx_hash = tx_included.tx_hash;
-            let block = tx_included.block;
-            let result = Message_::result_from_events(events.clone())?;
-            Ok(TransactionIncluded {
-                tx_hash,
-                block,
-                events,
-                result,
-            })
-        }))
+        client.submit_transaction(transaction).await
     }
 
     async fn block_header(&self, block_hash: BlockHash) -> Result<BlockHeader, Error> {

--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -59,6 +59,7 @@ async fn register_project() {
         let random_fee = random_balance();
         let message = random_register_project_message(&domain, checkpoint_id);
         let tx_included = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
+        assert_eq!(tx_included.result, Ok(()));
 
         let project = client
             .get_project(message.project_name.clone(), message.project_domain.clone())
@@ -69,15 +70,6 @@ async fn register_project() {
         assert_eq!(project.domain.clone(), message.project_domain.clone());
         assert_eq!(project.current_cp.clone(), checkpoint_id);
         assert_eq!(project.metadata.clone(), message.metadata.clone());
-
-        assert_eq!(
-            tx_included.events[0],
-            RegistryEvent::ProjectRegistered(
-                message.project_name.clone(),
-                message.project_domain.clone()
-            )
-            .into()
-        );
 
         let has_project = client
             .list_projects()
@@ -148,11 +140,6 @@ async fn register_member() {
     .await;
     assert_eq!(tx_applied.result, Ok(()));
 
-    assert_eq!(
-        tx_applied.events[0],
-        RegistryEvent::MemberRegistered(user_id.clone(), org_id.clone()).into()
-    );
-
     let re_org: Org = client.get_org(org_id.clone()).await.unwrap().unwrap();
     assert_eq!(re_org.members.len(), 2);
     assert!(
@@ -191,11 +178,6 @@ async fn register_org() {
     let random_fee = random_balance();
     let tx_included =
         submit_ok_with_fee(&client, &author, register_org_message.clone(), random_fee).await;
-
-    assert_eq!(
-        tx_included.events[0],
-        RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()
-    );
     assert_eq!(tx_included.result, Ok(()));
 
     let opt_org = client
@@ -225,11 +207,7 @@ async fn register_user() {
 
     let register_user_message = random_register_user_message();
     let tx_included = submit_ok(&client, &author, register_user_message.clone()).await;
-
-    assert_eq!(
-        tx_included.events[0],
-        RegistryEvent::UserRegistered(register_user_message.user_id.clone()).into(),
-    );
+    assert_eq!(tx_included.result, Ok(()));
 
     let maybe_user = client
         .get_user(register_user_message.user_id.clone())

--- a/runtime-tests/tests/member_registration.rs
+++ b/runtime-tests/tests/member_registration.rs
@@ -44,12 +44,8 @@ async fn register_member() {
         org_id: register_org.org_id.clone(),
         user_id: member_user_id,
     };
-    let tx_applied = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
-
-    assert_eq!(
-        tx_applied.events[0],
-        RegistryEvent::MemberRegistered(message.clone().user_id, message.clone().org_id).into()
-    );
+    let tx_included = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
+    assert_eq!(tx_included.result, Ok(()));
 
     // Fetch the org again
     let re_org = client

--- a/runtime-tests/tests/org_registration.rs
+++ b/runtime-tests/tests/org_registration.rs
@@ -31,10 +31,6 @@ async fn register_org() {
     let register_org_message = random_register_org_message();
     let tx_included =
         submit_ok_with_fee(&client, &author, register_org_message.clone(), random_fee).await;
-
-    assert!(tx_included
-        .events
-        .contains(&RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()));
     assert_eq!(tx_included.result, Ok(()));
 
     assert!(
@@ -132,10 +128,6 @@ async fn unregister_org() {
 
     let register_org_message = random_register_org_message();
     let tx_included = submit_ok(&client, &author, register_org_message.clone()).await;
-
-    assert!(tx_included
-        .events
-        .contains(&RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()));
     assert_eq!(tx_included.result, Ok(()));
 
     assert!(
@@ -173,10 +165,6 @@ async fn unregister_org_bad_actor() {
     let register_org_message = random_register_org_message();
 
     let tx_included = submit_ok(&client, &author, register_org_message.clone()).await;
-
-    assert!(tx_included
-        .events
-        .contains(&RegistryEvent::OrgRegistered(register_org_message.org_id.clone()).into()));
     assert_eq!(tx_included.result, Ok(()));
 
     assert!(

--- a/runtime-tests/tests/project_registration.rs
+++ b/runtime-tests/tests/project_registration.rs
@@ -57,6 +57,7 @@ async fn register_project() {
         let random_fee = random_balance();
         let message = random_register_project_message(&domain, checkpoint_id);
         let tx_included = submit_ok_with_fee(&client, &author, message.clone(), random_fee).await;
+        assert_eq!(tx_included.result, Ok(()));
 
         let project = client
             .get_project(message.project_name.clone(), message.project_domain.clone())
@@ -67,15 +68,6 @@ async fn register_project() {
         assert_eq!(project.domain.clone(), message.project_domain.clone());
         assert_eq!(project.current_cp.clone(), checkpoint_id);
         assert_eq!(project.metadata.clone(), message.metadata.clone());
-
-        assert_eq!(
-            tx_included.events[0],
-            RegistryEvent::ProjectRegistered(
-                message.project_name.clone(),
-                message.project_domain.clone()
-            )
-            .into()
-        );
 
         let has_project = client
             .list_projects()

--- a/runtime-tests/tests/user_registration.rs
+++ b/runtime-tests/tests/user_registration.rs
@@ -31,10 +31,7 @@ async fn register_user() {
     let random_fee = random_balance();
     let tx_included =
         submit_ok_with_fee(&client, &alice, register_user_message.clone(), random_fee).await;
-
-    assert!(tx_included
-        .events
-        .contains(&RegistryEvent::UserRegistered(register_user_message.user_id.clone()).into()));
+    assert_eq!(tx_included.result, Ok(()));
 
     assert!(
         user_exists(&client, register_user_message.user_id.clone()).await,
@@ -120,9 +117,6 @@ async fn unregister_user() {
 
     // Registration.
     let tx_included = submit_ok(&client, &alice, register_user_message.clone()).await;
-    assert!(tx_included
-        .events
-        .contains(&RegistryEvent::UserRegistered(register_user_message.user_id.clone()).into()));
     assert!(tx_included.result.is_ok());
     assert!(
         user_exists(&client, register_user_message.user_id.clone()).await,


### PR DESCRIPTION
We stop exposing events as part of the public client API in `TransactionIncluded`. The `events` field is not used by upstream. Events also require versioning when the runtime is upgraded. To simplify compatibility between runtime versions we stop exposing events.