### PR TITLE
Simplify `Message::Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Upcoming
 
 ### Breaking changes
 
+* client: Replaced the associated `Message::Result` type with `Message::Output`.
+  This should require no changes on the user’s side since
+  `TransactionIncluded::result` remains structurally equal.
 * runtime: Tx author pays for `UnregisterOrg`
 * client: Remove `TransactionIncluded::events` field.
 * client: Offline transaction signing now requires users to manually specify the

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -178,7 +178,7 @@ pub struct TransactionIncluded<Message_: Message> {
     /// The result of the runtime message.
     ///
     /// See [Message::result_from_events].
-    pub result: Message_::Result,
+    pub result: Result<Message_::Output, TransactionError>,
 }
 
 /// Return type for all [ClientT] methods.

--- a/client/src/message.rs
+++ b/client/src/message.rs
@@ -28,22 +28,29 @@ type EventParseError = String;
 /// For every [RuntimeCall] that is exposed to the user we implement [Message] for the parameters
 /// struct of the runtime message.
 pub trait Message: Send + 'static {
-    /// Result of executing the message in the runtime that is presented to the client user.
-    type Result: Send + 'static;
+    /// Output of a successfully applied message.
+    ///
+    /// This value is extracted from the events that are dispatched when the message is executed in
+    /// a block.
+    type Output: Send + 'static;
 
     /// Parse all runtime events emitted by the message and return the appropriate message result.
     ///
     /// Returns an error if the event list is not well formed. For example if an expected event is
     /// missing.
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError>;
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError>;
 
     fn into_runtime_call(self) -> RuntimeCall;
 }
 
 impl Message for message::RegisterProject {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "ProjectRegistered", |event| match event {
@@ -60,9 +67,11 @@ impl Message for message::RegisterProject {
 }
 
 impl Message for message::RegisterMember {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "MemberRegistered", |event| match event {
@@ -79,9 +88,11 @@ impl Message for message::RegisterMember {
 }
 
 impl Message for message::RegisterOrg {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "OrgRegistered", |event| match event {
@@ -98,9 +109,11 @@ impl Message for message::RegisterOrg {
 }
 
 impl Message for message::UnregisterOrg {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "OrgUnregistered", |event| match event {
@@ -117,13 +130,15 @@ impl Message for message::UnregisterOrg {
 }
 
 impl Message for message::RegisterUser {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
     fn into_runtime_call(self) -> RuntimeCall {
         registry::Call::register_user(self).into()
     }
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
 
         match dispatch_result {
@@ -137,9 +152,11 @@ impl Message for message::RegisterUser {
 }
 
 impl Message for message::UnregisterUser {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "UserUnregistered", |event| match event {
@@ -156,9 +173,11 @@ impl Message for message::UnregisterUser {
 }
 
 impl Message for message::CreateCheckpoint {
-    type Result = Result<CheckpointId, TransactionError>;
+    type Output = CheckpointId;
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "CheckpointCreated", |event| match event {
@@ -177,9 +196,11 @@ impl Message for message::CreateCheckpoint {
 }
 
 impl Message for message::SetCheckpoint {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let dispatch_result = get_dispatch_result(&events)?;
         match dispatch_result {
             Ok(()) => find_event(&events, "CheckpointSet", |event| match event {
@@ -200,9 +221,11 @@ impl Message for message::SetCheckpoint {
 }
 
 impl Message for message::Transfer {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         get_dispatch_result(&events)
     }
 
@@ -212,9 +235,11 @@ impl Message for message::Transfer {
 }
 
 impl Message for message::TransferFromOrg {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         get_dispatch_result(&events)
     }
 
@@ -224,11 +249,13 @@ impl Message for message::TransferFromOrg {
 }
 
 impl Message for message::UpdateRuntime {
-    type Result = Result<(), TransactionError>;
+    type Output = ();
 
     /// The only unequivocal sign we get that a wasm update was successful is the
     /// `RawEvent::CodeUpdated` event. Anything else is considered a failed update.
-    fn result_from_events(events: Vec<Event>) -> Result<Self::Result, EventParseError> {
+    fn result_from_events(
+        events: Vec<Event>,
+    ) -> Result<Result<Self::Output, TransactionError>, EventParseError> {
         let error: TransactionError = RegistryError::FailedChainRuntimeUpdate.into();
         find_event(&events, "System", |event| match event {
             Event::system(system_event) => match system_event {


### PR DESCRIPTION
We replace the associated `Message::Result` type with `Message::Output`