### PR TITLE
Add transaction_index to runtime API

### DIFF
--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -23,9 +23,9 @@ use sp_runtime::{traits::Block as _, traits::Hash as _, BuildStorage as _, Diges
 use sp_state_machine::backend::Backend as _;
 
 use radicle_registry_runtime::{
+    event,
     genesis::{BalancesConfig, GenesisConfig},
-    registry, runtime_api, AccountId, Block, EventRecord, Hash, Hashing, Header, Runtime,
-    RuntimeVersion,
+    registry, runtime_api, AccountId, Block, Hash, Hashing, Header, Runtime, RuntimeVersion,
 };
 
 use crate::backend;
@@ -137,7 +137,10 @@ impl Emulator {
 
     /// Add a block with `extrinsics` to the chain. Returns the added block and a list of events
     /// recorded during the execution of the block.
-    fn add_block(&self, extrinsics: Vec<backend::UncheckedExtrinsic>) -> (Block, Vec<EventRecord>) {
+    fn add_block(
+        &self,
+        extrinsics: Vec<backend::UncheckedExtrinsic>,
+    ) -> (Block, Vec<event::Record>) {
         let mut state = self.state.lock().unwrap();
 
         let new_tip_header_init = Header {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,8 +55,6 @@ pub type Signature = ed25519::Signature;
 /// Same as  [sp_runtime::traits::Hash::Output] for [Hashing].
 pub type Hash = sp_core::H256;
 
-pub type EventRecord = frame_system::EventRecord<runtime::Event, Hash>;
-
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 
@@ -118,8 +116,21 @@ pub mod store {
 }
 
 pub mod event {
+    pub use crate::runtime::Event;
+    pub type Record = frame_system::EventRecord<crate::runtime::Event, crate::Hash>;
     pub type Registry = crate::registry::Event;
     pub type System = frame_system::Event<crate::Runtime>;
+
+    /// Return the index of the transaction in the block that dispatched the event.
+    ///
+    /// Returns `None` if the event was not dispatched as part of a transaction.
+    #[cfg(feature = "std")]
+    pub fn transaction_index(record: &Record) -> Option<u32> {
+        match record.phase {
+            frame_system::Phase::ApplyExtrinsic(i) => Some(i),
+            _ => None,
+        }
+    }
 }
 
 pub mod call {


### PR DESCRIPTION
We again reduce the coupling of the client to `frame_system` by internalizing access to the transaction index of an event.