### PR TITLE
Improve message event extraction

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -17,6 +17,8 @@ use failure::{Compat, Fail};
 use jsonrpc_core_client::RpcError;
 use parity_scale_codec::Error as CodecError;
 
+use crate::message::EventExtractionError;
+
 /// Error that may be returned by any of the [crate::ClientT] methods
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -32,6 +34,14 @@ pub enum Error {
     /// Chain is running an incompatible runtime specification version
     #[error("Chain is running an incompatible runtime specification version {0}")]
     IncompatibleRuntimeVersion(u32),
+
+    /// Failed to extract required events for a transaction
+    #[error("Failed to extract required events for transaction {tx_hash}")]
+    EventExtraction {
+        error: EventExtractionError,
+        tx_hash: crate::TxHash,
+    },
+
     /// Other error
     #[error("Other error: {0}")]
     Other(String),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -169,7 +169,8 @@ impl ClientT for Client {
             let events = tx_included.events;
             let tx_hash = tx_included.tx_hash;
             let block = tx_included.block;
-            let result = Message_::result_from_events(events)?;
+            let result = Message_::result_from_events(events)
+                .map_err(|error| Error::EventExtraction { error, tx_hash })?;
             Ok(TransactionIncluded {
                 tx_hash,
                 block,


### PR DESCRIPTION
We refactor the message event extraction to prepare for event compatibility and to make the code more maintainable in general.

* Structured `EventExtractionError` for event extraction
* Refactor helper functions for event extraction to reduce duplicate code.