### PR TITLE
Extract node metrics into module

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,6 +22,7 @@ mod blockchain;
 mod chain_spec;
 mod cli;
 mod logger;
+mod metrics;
 mod pow;
 mod service;
 

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -1,0 +1,162 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use futures::StreamExt;
+use std::convert::TryFrom;
+use std::future::Future;
+
+// TODO remove in favor of substrate_prometheus_endpoint::prometheus after substrate upgrade
+use prometheus::core::Atomic;
+use sc_client::{light::blockchain::AuxStore, BlockImportNotification, BlockchainEvents as _};
+use sc_service::{AbstractService, Error};
+use sp_runtime::{generic::BlockId, traits::Block as _};
+use substrate_prometheus_endpoint::{Gauge, Registry, U64};
+
+use crate::pow::Difficulty;
+
+pub fn register_metrics<S>(service: &S) -> Result<(), Error>
+where
+    S: AbstractService,
+    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
+{
+    let registry = match service.prometheus_registry() {
+        Some(registry) => registry,
+        None => {
+            log::warn!("Prometheus is disabled, some metrics won't be collected");
+            return Ok(());
+        }
+    };
+    register_best_block_metrics(service, &registry)?;
+    Ok(())
+}
+
+fn register_best_block_metrics<S>(service: &S, registry: &Registry) -> Result<(), Error>
+where
+    S: AbstractService,
+    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
+{
+    let update_difficulty_gauge = create_difficulty_gauge_updater(service, registry)?;
+    let update_block_size_gauges = create_block_size_gauges_updater(service, registry)?;
+    let update_reorganization_gauges = create_reorganization_gauges_updater(registry)?;
+    let task = service
+        .client()
+        .import_notification_stream()
+        .for_each(move |info| {
+            if info.is_new_best {
+                update_difficulty_gauge(&info);
+                update_block_size_gauges(&info);
+                update_reorganization_gauges(&info);
+            }
+            futures::future::ready(())
+        });
+    spawn_metric_task(service, "best_block", task);
+    Ok(())
+}
+
+fn create_difficulty_gauge_updater<S>(
+    service: &S,
+    registry: &Registry,
+) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error>
+where
+    S: AbstractService,
+    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
+{
+    let difficulty_gauge = register_gauge::<U64>(
+        &registry,
+        "best_block_difficulty",
+        "The difficulty of the best block in the chain",
+    )?;
+    let client = service.client();
+    let updater = move |info: &BlockImportNotification<S::Block>| {
+        let difficulty_res =
+            sc_consensus_pow::PowAux::<Difficulty>::read::<_, S::Block>(&*client, &info.hash);
+        let difficulty = match difficulty_res {
+            Ok(difficulty) => u64::try_from(difficulty.difficulty).unwrap_or(u64::MAX),
+            Err(_) => return,
+        };
+        difficulty_gauge.set(difficulty);
+    };
+    Ok(updater)
+}
+
+fn create_block_size_gauges_updater<S: AbstractService>(
+    service: &S,
+    registry: &Registry,
+) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error> {
+    let transactions_gauge = register_gauge::<U64>(
+        &registry,
+        "best_block_transactions",
+        "Number of transactions in the best block in the chain",
+    )?;
+    let length_gauge = register_gauge::<U64>(
+        &registry,
+        "best_block_length",
+        "Length in bytes of the best block in the chain",
+    )?;
+    let client = service.client();
+    let updater = move |info: &BlockImportNotification<S::Block>| {
+        let body = match client.body(&BlockId::hash(info.hash)) {
+            Ok(Some(body)) => body,
+            _ => return,
+        };
+        transactions_gauge.set(body.len() as u64);
+        let encoded_block = S::Block::encode_from(&info.header, &body);
+        length_gauge.set(encoded_block.len() as u64);
+    };
+    Ok(updater)
+}
+
+fn create_reorganization_gauges_updater<S: AbstractService>(
+    registry: &Registry,
+) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error> {
+    let reorg_length_gauge = register_gauge::<U64>(
+        &registry,
+        "best_block_reorganization_length",
+        "Number of blocks rolled back to establish the best block in the chain",
+    )?;
+    let reorg_count_gauge = register_gauge::<U64>(
+        &registry,
+        "best_block_reorganization_count",
+        "Number of best block reorganizations, which occurred in the chain",
+    )?;
+    let updater = move |info: &BlockImportNotification<S::Block>| {
+        reorg_length_gauge.set(info.retracted.len() as u64);
+        if !info.retracted.is_empty() {
+            reorg_count_gauge.inc();
+        }
+    };
+    Ok(updater)
+}
+
+fn register_gauge<P: Atomic + 'static>(
+    registry: &Registry,
+    gauge_name: &str,
+    gauge_help: &str,
+) -> Result<Gauge<P>, Error> {
+    let gauge = Gauge::new(gauge_name, gauge_help)
+        .map_err(|e| format!("failed to create metric gauge '{}': {}", gauge_name, e))?;
+    substrate_prometheus_endpoint::register(gauge, &registry)
+        .map_err(|e| format!("failed to register metric gauge '{}': {}", gauge_name, e).into())
+}
+
+fn spawn_metric_task(
+    service: &impl AbstractService,
+    name: &str,
+    task: impl Future<Output = ()> + Send + 'static,
+) {
+    // TODO turn into passing a string after upgrade
+    let task_name = Box::leak(format!("{}_metric_notifier", name).into_boxed_str());
+    service.spawn_task(&*task_name, task);
+}

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -19,24 +19,20 @@
 
 use futures::StreamExt;
 use std::convert::TryFrom;
-use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 // TODO remove in favor of substrate_prometheus_endpoint::prometheus after substrate upgrade
-use prometheus::core::Atomic;
-use sc_client::BlockImportNotification;
-use sc_client::{light::blockchain::AuxStore, BlockchainEvents as _, LongestChain};
+use sc_client::{BlockchainEvents as _, LongestChain};
 use sc_executor::native_executor_instance;
 use sc_service::{AbstractService, Configuration, Error, ServiceBuilder};
 use sp_inherents::InherentDataProviders;
-use sp_runtime::generic::BlockId;
-use sp_runtime::traits::Block as _;
-use substrate_prometheus_endpoint::{Gauge, Registry, U64};
+
+use radicle_registry_runtime::{registry::AuthoringInherentData, AccountId, RuntimeApi};
 
 use crate::blockchain::Block;
-use crate::pow::{blake3_pow::Blake3Pow, config::Config, dummy_pow::DummyPow, Difficulty};
-use radicle_registry_runtime::{registry::AuthoringInherentData, AccountId, RuntimeApi};
+use crate::metrics::register_metrics;
+use crate::pow::{blake3_pow::Blake3Pow, config::Config, dummy_pow::DummyPow};
 
 // Our native executor instance.
 native_executor_instance!(
@@ -227,141 +223,6 @@ pub fn new_light(config: Configuration) -> Result<impl AbstractService, Error> {
         .build()?;
     register_metrics(&service)?;
     Ok(service)
-}
-
-fn register_metrics<S>(service: &S) -> Result<(), Error>
-where
-    S: AbstractService,
-    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
-{
-    let registry = match service.prometheus_registry() {
-        Some(registry) => registry,
-        None => {
-            log::warn!("Prometheus is disabled, some metrics won't be collected");
-            return Ok(());
-        }
-    };
-    register_best_block_metrics(service, &registry)?;
-    Ok(())
-}
-
-fn register_best_block_metrics<S>(service: &S, registry: &Registry) -> Result<(), Error>
-where
-    S: AbstractService,
-    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
-{
-    let update_difficulty_gauge = create_difficulty_gauge_updater(service, registry)?;
-    let update_block_size_gauges = create_block_size_gauges_updater(service, registry)?;
-    let update_reorganization_gauges = create_reorganization_gauges_updater(registry)?;
-    let task = service
-        .client()
-        .import_notification_stream()
-        .for_each(move |info| {
-            if info.is_new_best {
-                update_difficulty_gauge(&info);
-                update_block_size_gauges(&info);
-                update_reorganization_gauges(&info);
-            }
-            futures::future::ready(())
-        });
-    spawn_metric_task(service, "best_block", task);
-    Ok(())
-}
-
-fn create_difficulty_gauge_updater<S>(
-    service: &S,
-    registry: &Registry,
-) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error>
-where
-    S: AbstractService,
-    sc_client::Client<S::Backend, S::CallExecutor, S::Block, S::RuntimeApi>: AuxStore,
-{
-    let difficulty_gauge = register_gauge::<U64>(
-        &registry,
-        "best_block_difficulty",
-        "The difficulty of the best block in the chain",
-    )?;
-    let client = service.client();
-    let updater = move |info: &BlockImportNotification<S::Block>| {
-        let difficulty_res =
-            sc_consensus_pow::PowAux::<Difficulty>::read::<_, S::Block>(&*client, &info.hash);
-        let difficulty = match difficulty_res {
-            Ok(difficulty) => u64::try_from(difficulty.difficulty).unwrap_or(u64::MAX),
-            Err(_) => return,
-        };
-        difficulty_gauge.set(difficulty);
-    };
-    Ok(updater)
-}
-
-fn create_block_size_gauges_updater<S: AbstractService>(
-    service: &S,
-    registry: &Registry,
-) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error> {
-    let transactions_gauge = register_gauge::<U64>(
-        &registry,
-        "best_block_transactions",
-        "Number of transactions in the best block in the chain",
-    )?;
-    let length_gauge = register_gauge::<U64>(
-        &registry,
-        "best_block_length",
-        "Length in bytes of the best block in the chain",
-    )?;
-    let client = service.client();
-    let updater = move |info: &BlockImportNotification<S::Block>| {
-        let body = match client.body(&BlockId::hash(info.hash)) {
-            Ok(Some(body)) => body,
-            _ => return,
-        };
-        transactions_gauge.set(body.len() as u64);
-        let encoded_block = S::Block::encode_from(&info.header, &body);
-        length_gauge.set(encoded_block.len() as u64);
-    };
-    Ok(updater)
-}
-
-fn create_reorganization_gauges_updater<S: AbstractService>(
-    registry: &Registry,
-) -> Result<impl Fn(&BlockImportNotification<S::Block>), Error> {
-    let reorg_length_gauge = register_gauge::<U64>(
-        &registry,
-        "best_block_reorganization_length",
-        "Number of blocks rolled back to establish the best block in the chain",
-    )?;
-    let reorg_count_gauge = register_gauge::<U64>(
-        &registry,
-        "best_block_reorganization_count",
-        "Number of best block reorganizations, which occurred in the chain",
-    )?;
-    let updater = move |info: &BlockImportNotification<S::Block>| {
-        reorg_length_gauge.set(info.retracted.len() as u64);
-        if !info.retracted.is_empty() {
-            reorg_count_gauge.inc();
-        }
-    };
-    Ok(updater)
-}
-
-fn register_gauge<P: Atomic + 'static>(
-    registry: &Registry,
-    gauge_name: &str,
-    gauge_help: &str,
-) -> Result<Gauge<P>, Error> {
-    let gauge = Gauge::new(gauge_name, gauge_help)
-        .map_err(|e| format!("failed to create metric gauge '{}': {}", gauge_name, e))?;
-    substrate_prometheus_endpoint::register(gauge, &registry)
-        .map_err(|e| format!("failed to register metric gauge '{}': {}", gauge_name, e).into())
-}
-
-fn spawn_metric_task(
-    service: &impl AbstractService,
-    name: &str,
-    task: impl Future<Output = ()> + Send + 'static,
-) {
-    // TODO turn into passing a string after upgrade
-    let task_name = Box::leak(format!("{}_metric_notifier", name).into_boxed_str());
-    service.spawn_task(&*task_name, task);
 }
 
 /// Build a new service to be used for one-shot commands.


### PR DESCRIPTION
We extract the metrics registration code from the `service` module and put it into its own module. This should make the substrate update that changes the metrics APIs easier.