### PR TITLE
Add missing tip header error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* client: Change signature of `Client::block_header` from `Result<BlockHeader>,
+  Error>` to `Result<Option<BlockHeader>, Error>`.
 * runtime: Forbid claim of unregistered ids
 * client: Eliminate state wrapper types returned from `Client::get_org`,
   `Client::get_project`, `Client::get_user`, and `Client::get_checktpoin`.

--- a/client/src/backend/emulator.rs
+++ b/client/src/backend/emulator.rs
@@ -230,17 +230,16 @@ impl backend::Backend for Emulator {
         Ok(keys)
     }
 
-    async fn block_header(&self, block_hash_opt: Option<BlockHash>) -> Result<BlockHeader, Error> {
+    async fn block_header(
+        &self,
+        block_hash_opt: Option<BlockHash>,
+    ) -> Result<Option<BlockHeader>, Error> {
         let state = self.state.lock().unwrap();
         let block_hash = match block_hash_opt {
             Some(block_hash) => block_hash,
-            None => return Ok(state.tip_header.clone()),
+            None => return Ok(Some(state.tip_header.clone())),
         };
-        state
-            .headers
-            .get(&block_hash)
-            .cloned()
-            .ok_or_else(|| format!("No block header found for hash {}", block_hash).into())
+        Ok(state.headers.get(&block_hash).cloned())
     }
 
     fn get_genesis_hash(&self) -> Hash {

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -69,7 +69,7 @@ pub trait Backend {
 
     /// Fetch the header of the given block hash.
     /// If the block hash is `None`, fetch the header of the best chain tip.
-    async fn block_header(&self, block_hash: Option<BlockHash>) -> Result<Header, Error>;
+    async fn block_header(&self, block_hash: Option<BlockHash>) -> Result<Option<Header>, Error>;
 
     /// Get the genesis hash of the blockchain. This must be obtained on backend creation.
     fn get_genesis_hash(&self) -> Hash;

--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -203,16 +203,16 @@ impl backend::Backend for RemoteNode {
         Ok(keys.into_iter().map(|key| key.0).collect())
     }
 
-    async fn block_header(&self, block_hash: Option<BlockHash>) -> Result<BlockHeader, Error> {
+    async fn block_header(
+        &self,
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<BlockHeader>, Error> {
         self.rpc
             .chain
             .header(block_hash)
             .compat()
-            .await?
-            .ok_or_else(|| match block_hash {
-                Some(hash) => format!("Header not found for block hash {}", hash).into(),
-                None => "Header not found for the best chain tip".into(),
-            })
+            .await
+            .map_err(Error::from)
     }
 
     fn get_genesis_hash(&self) -> Hash {

--- a/client/src/backend/remote_node_with_executor.rs
+++ b/client/src/backend/remote_node_with_executor.rs
@@ -85,7 +85,10 @@ impl backend::Backend for RemoteNodeWithExecutor {
         handle.await
     }
 
-    async fn block_header(&self, block_hash: Option<BlockHash>) -> Result<BlockHeader, Error> {
+    async fn block_header(
+        &self,
+        block_hash: Option<BlockHash>,
+    ) -> Result<Option<BlockHeader>, Error> {
         let backend = self.backend.clone();
         let handle = Executor01CompatExt::compat(self.runtime.executor())
             .spawn_with_handle(async move { backend.block_header(block_hash).await })

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
         tx_hash: crate::TxHash,
     },
 
+    #[error("Could not obtain header of tip of best chain")]
+    BestChainTipHeaderMissing,
+
     /// Other error
     #[error("Other error: {0}")]
     Other(String),

--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -117,7 +117,7 @@ pub trait ClientT {
     ) -> Result<state::AccountTransactionIndex, Error>;
 
     /// Fetch the header of the given block hash
-    async fn block_header(&self, block_hash: BlockHash) -> Result<BlockHeader, Error>;
+    async fn block_header(&self, block_hash: BlockHash) -> Result<Option<BlockHeader>, Error>;
 
     /// Fetch the header of the best chain tip
     async fn block_header_best_chain(&self) -> Result<BlockHeader, Error>;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -205,12 +205,13 @@ impl ClientT for Client {
         client.submit_transaction(transaction).await
     }
 
-    async fn block_header(&self, block_hash: BlockHash) -> Result<BlockHeader, Error> {
+    async fn block_header(&self, block_hash: BlockHash) -> Result<Option<BlockHeader>, Error> {
         self.backend.block_header(Some(block_hash)).await
     }
 
     async fn block_header_best_chain(&self) -> Result<BlockHeader, Error> {
-        self.backend.block_header(None).await
+        let maybe_header = self.backend.block_header(None).await?;
+        maybe_header.ok_or_else(|| Error::BestChainTipHeaderMissing)
     }
 
     fn genesis_hash(&self) -> Hash {


### PR DESCRIPTION
A step towards eliminating `Error::Other` in the client. Instead of returning an error if a block is missing we return an option. For the best chain tip we create a dedicated error variant.