### PR TITLE
Eliminate client::Error::Other variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Upcoming
 
 ### Breaking changes
 
+* client: Eliminate `Error::Other` variant and replace it with dedicated
+  variants for different errors.
 * client: Change signature of `Client::block_header` from `Result<BlockHeader>,
   Error>` to `Result<Option<BlockHeader>, Error>`.
 * runtime: Forbid claim of unregistered ids

--- a/client/src/backend/mod.rs
+++ b/client/src/backend/mod.rs
@@ -29,6 +29,8 @@ pub use emulator::{Emulator, EmulatorControl, BLOCK_AUTHOR as EMULATOR_BLOCK_AUT
 pub use remote_node::RemoteNode;
 pub use remote_node_with_executor::RemoteNodeWithExecutor;
 
+pub type TransactionStatus = sp_transaction_pool::TransactionStatus<TxHash, BlockHash>;
+
 /// Indicator that a transaction has been included in a block and has run in the runtime.
 ///
 /// Obtained after a transaction has been submitted and processed.


### PR DESCRIPTION
Eliminate the `client::Error::Other` variant and replace it with dedicated variants for the different possible errors.