### PR TITLE
Rename client Codec error to StateDecoding

### DIFF
--- a/client/src/backend/remote_node.rs
+++ b/client/src/backend/remote_node.rs
@@ -149,7 +149,12 @@ impl RemoteNode {
             .await?
             .unwrap_or_default();
         let event_records =
-            EventRecord::decode_vec(runtime_spec_version, &events_data).map_err(Error::Codec)?;
+            EventRecord::decode_vec(runtime_spec_version, &events_data).map_err(|error| {
+                Error::StateDecoding {
+                    error,
+                    key: SYSTEM_EVENTS_STORAGE_KEY.to_vec(),
+                }
+            })?;
 
         let signed_block = self
             .rpc

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -22,9 +22,14 @@ use crate::event::EventExtractionError;
 /// Error that may be returned by any of the [crate::ClientT] methods
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Decoding the received data failed
-    #[error("Decoding the received data failed")]
-    Codec(#[from] CodecError),
+    /// Failed to decode state value
+    #[error("Failed to decode state value")]
+    StateDecoding {
+        #[source]
+        error: CodecError,
+        /// Key for the value we tried to decode
+        key: Vec<u8>,
+    },
 
     /// Error from the underlying RPC connection
     #[error("Error from the underlying RPC connection")]


### PR DESCRIPTION
We rename the `Error::Codec` to `Error::StateDecoding` to make it explicit where this error originates. We also add the `key` parameter to simplify debugging.