### PR TITLE
End to end tests can run twice

### DIFF
--- a/client/tests/end_to_end.rs
+++ b/client/tests/end_to_end.rs
@@ -29,7 +29,7 @@ async fn register_project() {
     let _ = env_logger::try_init();
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let author = random_key_pair(&client).await;
+    let author = key_pair_with_funds(&client).await;
 
     for domain in generate_project_domains(&client, &author).await {
         let project_hash = H256::random();
@@ -272,7 +272,7 @@ async fn invalid_transaction() {
 async fn insufficient_fee() {
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let tx_author = key_pair_from_string("Alice");
+    let tx_author = key_pair_with_funds(&client).await;
     let insufficient_fee: Balance = 0;
 
     let whatever_message = random_register_org_message();
@@ -294,7 +294,7 @@ async fn insufficient_fee() {
 async fn insufficient_funds() {
     let node_host = url::Host::parse("127.0.0.1").unwrap();
     let client = Client::create_with_executor(node_host).await.unwrap();
-    let tx_author = key_pair_from_string("PoorActor");
+    let tx_author = ed25519::Pair::generate().0;
     assert_eq!(client.free_balance(&tx_author.public()).await.unwrap(), 0);
 
     let whatever_message = random_register_org_message();

--- a/runtime-tests/tests/block_rewards.rs
+++ b/runtime-tests/tests/block_rewards.rs
@@ -23,8 +23,9 @@ use sp_runtime::Permill;
 async fn block_rewards_credited() {
     let (client, _) = Client::new_emulator();
 
-    let alice = key_pair_from_string("Alice");
-    let bob = key_pair_from_string("Bob").public();
+    let alice = key_pair_with_funds(&client).await;
+    let bob = ed25519::Pair::generate().0.public();
+    let author_balance = client.free_balance(&EMULATOR_BLOCK_AUTHOR).await.unwrap();
 
     let fee = 3000;
     submit_ok_with_fee(
@@ -38,7 +39,7 @@ async fn block_rewards_credited() {
     )
     .await;
 
-    let rewards = client.free_balance(&EMULATOR_BLOCK_AUTHOR).await.unwrap();
+    let rewards = client.free_balance(&EMULATOR_BLOCK_AUTHOR).await.unwrap() - author_balance;
     let fee_reward = Permill::from_percent(99) * fee;
     assert_eq!(rewards, fee_reward + BLOCK_REWARD);
 }

--- a/runtime-tests/tests/checkpoint_creation.rs
+++ b/runtime-tests/tests/checkpoint_creation.rs
@@ -24,7 +24,7 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn create_checkpoint() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
 
     let project_hash1 = H256::random();
     let checkpoint_id1 = submit_ok(
@@ -72,7 +72,7 @@ async fn create_checkpoint() {
 #[async_std::test]
 async fn create_checkpoint_without_parent() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
 
     let project_hash = H256::random();
     let previous_checkpoint_id = Some(CheckpointId::random());

--- a/runtime-tests/tests/org_registration.rs
+++ b/runtime-tests/tests/org_registration.rs
@@ -58,7 +58,7 @@ async fn register_org() {
 #[async_std::test]
 async fn register_org_no_user() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
 
     let initial_balance = client.free_balance(&alice.public()).await.unwrap();
     let random_fee = random_balance();
@@ -103,7 +103,7 @@ async fn register_with_id_taken_by_org() {
 #[async_std::test]
 async fn register_with_taken_user_id() {
     let (client, _) = Client::new_emulator();
-    let author = key_pair_from_string("Alice");
+    let author = key_pair_with_funds(&client).await;
     let id = random_id();
 
     let register_user_message = message::RegisterUser {

--- a/runtime-tests/tests/project_registration.rs
+++ b/runtime-tests/tests/project_registration.rs
@@ -27,7 +27,7 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn register_project() {
     let (client, _) = Client::new_emulator();
-    let author = random_key_pair(&client).await;
+    let author = key_pair_with_funds(&client).await;
 
     for domain in generate_project_domains(&client, &author).await {
         let project_hash = H256::random();
@@ -138,7 +138,7 @@ async fn register_project_under_inexistent_domain() {
 #[async_std::test]
 async fn re_register_project_same_domain_entity() {
     let (client, _) = Client::new_emulator();
-    let author = random_key_pair(&client).await;
+    let author = key_pair_with_funds(&client).await;
 
     for domain in generate_project_domains(&client, &author).await {
         let checkpoint_id = submit_ok(
@@ -279,7 +279,7 @@ async fn register_same_project_name_under_different_users() {
 #[async_std::test]
 async fn register_project_with_bad_checkpoint() {
     let (client, _) = Client::new_emulator();
-    let author = random_key_pair(&client).await;
+    let author = key_pair_with_funds(&client).await;
     let checkpoint_id = H256::random();
 
     for domain in generate_project_domains(&client, &author).await {
@@ -303,7 +303,7 @@ async fn register_project_with_bad_checkpoint() {
 #[async_std::test]
 async fn register_project_with_bad_actor() {
     let (client, _) = Client::new_emulator();
-    let author = random_key_pair(&client).await;
+    let author = key_pair_with_funds(&client).await;
     let (bad_actor, _) = key_pair_with_associated_user(&client).await;
 
     for domain in generate_project_domains(&client, &author).await {

--- a/runtime-tests/tests/transfer.rs
+++ b/runtime-tests/tests/transfer.rs
@@ -24,8 +24,8 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn transfer_fail() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
-    let bob = key_pair_from_string("Bob").public();
+    let alice = key_pair_with_funds(&client).await;
+    let bob = key_pair_with_funds(&client).await.public();
 
     let balance_alice = client.free_balance(&alice.public()).await.unwrap();
     let tx_included = submit_ok(
@@ -45,8 +45,8 @@ async fn transfer_fail() {
 #[async_std::test]
 async fn transfer_any_amount() {
     let (client, _) = Client::new_emulator();
-    let donator = key_pair_from_string("Alice");
-    let receipient = key_pair_from_string("Bob").public();
+    let donator = key_pair_with_funds(&client).await;
+    let receipient = ed25519::Pair::generate().0.public();
 
     for amount in (1..10000).step_by(500) {
         let tx_included = submit_ok(
@@ -74,7 +74,7 @@ async fn org_account_transfer() {
     let (client, _) = Client::new_emulator();
     let (author, _) = key_pair_with_associated_user(&client).await;
 
-    let bob = key_pair_from_string("Bob").public();
+    let bob = ed25519::Pair::generate().0.public();
     let (org_id, org) = register_random_org(&client, &author).await;
 
     let org_inigial_balance = client.free_balance(&org.account_id()).await.unwrap();
@@ -133,7 +133,7 @@ async fn org_account_transfer_non_member() {
 
     let initial_balance = client.free_balance(&org.account_id()).await.unwrap();
 
-    let bad_actor = key_pair_from_string("BadActor");
+    let bad_actor = ed25519::Pair::generate().0;
     // The bad actor needs funds to submit transactions.
     transfer(&client, &author, bad_actor.public(), 1000).await;
 

--- a/runtime-tests/tests/user_registration.rs
+++ b/runtime-tests/tests/user_registration.rs
@@ -24,7 +24,7 @@ use radicle_registry_test_utils::*;
 #[async_std::test]
 async fn register_user() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
     let initial_balance = client.free_balance(&alice.public()).await.unwrap();
 
     let register_user_message = random_register_user_message();
@@ -56,13 +56,13 @@ async fn register_user() {
 #[async_std::test]
 async fn register_with_id_taken_by_user() {
     let (client, _) = Client::new_emulator();
-    let author_x = key_pair_from_string("Alice");
+    let author_x = key_pair_with_funds(&client).await;
 
     let register_user_message = random_register_user_message();
     let tx_included_once = submit_ok(&client, &author_x, register_user_message.clone()).await;
     assert!(tx_included_once.result.is_ok());
 
-    let author_y = random_key_pair(&client).await;
+    let author_y = key_pair_with_funds(&client).await;
     let tx_included_twice = submit_ok(&client, &author_y, register_user_message.clone()).await;
     assert_eq!(
         tx_included_twice.result,
@@ -81,7 +81,7 @@ async fn register_with_id_taken_by_org() {
     let tx_included_org = submit_ok(&client, &author_x, register_org_message.clone()).await;
     assert_eq!(tx_included_org.result, Ok(()));
 
-    let author_y = random_key_pair(&client).await;
+    let author_y = key_pair_with_funds(&client).await;
     let register_user_message = message::RegisterUser { user_id: id };
     let tx_included_user = submit_ok(&client, &author_y, register_user_message.clone()).await;
     assert_eq!(
@@ -93,7 +93,7 @@ async fn register_with_id_taken_by_org() {
 #[async_std::test]
 async fn register_user_with_already_associated_account() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
     let register_first_user_message = random_register_user_message();
 
     let tx_included_first = submit_ok(&client, &alice, register_first_user_message.clone()).await;
@@ -164,7 +164,7 @@ async fn register_with_id_of_unregistered_org() {
 #[async_std::test]
 async fn unregister_user() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
 
     // Registration.
     let register_user_message = random_register_user_message();
@@ -262,7 +262,7 @@ async fn unregister_user_with_invalid_sender() {
 #[async_std::test]
 async fn unregister_user_with_no_associated_user() {
     let (client, _) = Client::new_emulator();
-    let alice = key_pair_from_string("Alice");
+    let alice = key_pair_with_funds(&client).await;
     let initial_balance = client.free_balance(&alice.public()).await.unwrap();
     let unregister_user_message = message::UnregisterUser {
         user_id: random_id(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -143,19 +143,15 @@ pub fn random_register_user_message() -> message::RegisterUser {
     }
 }
 
-pub fn key_pair_from_string(value: impl AsRef<str>) -> ed25519::Pair {
-    ed25519::Pair::from_string(format!("//{}", value.as_ref()).as_str(), None).unwrap()
+pub fn root_key_pair() -> ed25519::Pair {
+    ed25519::Pair::from_string("//Alice", None).unwrap()
 }
 
-/// Create a random a key pair from a random string. Equips the key pair account
-/// with enough funds to run transactions.
-pub async fn random_key_pair(client: &Client) -> ed25519::Pair {
-    let seed = &random_alnum_string(5);
-    let key_pair = key_pair_from_string(seed);
+/// Generate a random a key pair and equip the account with some funds.
+pub async fn key_pair_with_funds(client: &Client) -> ed25519::Pair {
+    let key_pair = ed25519::Pair::generate().0;
 
-    // Have Alice transfer 100.000 μRAD to this new account, necessary to submit transactions.
-    let alice = key_pair_from_string("Alice");
-    transfer(&client, &alice, key_pair.public(), 100_000).await;
+    transfer(&client, &root_key_pair(), key_pair.public(), 100_000).await;
 
     key_pair
 }
@@ -163,7 +159,7 @@ pub async fn random_key_pair(client: &Client) -> ed25519::Pair {
 /// Create a random key pair derived and register a user associated with it.
 /// Ensures that the account for the key pair is equipped with enough RAD to run transactions.
 pub async fn key_pair_with_associated_user(client: &Client) -> (ed25519::Pair, Id) {
-    let key_pair = random_key_pair(&client).await;
+    let key_pair = key_pair_with_funds(&client).await;
     let user_id = associate_key_pair_with_random_user(client, &key_pair).await;
 
     (key_pair, user_id)


### PR DESCRIPTION
We use randomly generate accounts instead of the “//Alice” root account throughout the tests. This enables us to run the end-to-end tests twice against the same state. This might also eliminate some conflicting transactions in the tests.