### PR TITLE
Don’t connect to peers as --dev node

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -240,6 +240,7 @@ impl Cli {
         if self.dev {
             let db = Arc::new(sp_database::MemDb::new());
             config.database = sc_service::config::DatabaseConfig::Custom(db);
+            config.network.transport = sc_network::config::TransportConfig::MemoryOnly;
         }
 
         if self.unsafe_rpc_external {


### PR DESCRIPTION
When the node is run with the `--dev` flag we disable the P2P networking.

Fixes #501 where the nodes from parallel builds would connect to each other and send transactions around.