### PR TITLE
Remove alloc_prelude feature

### DIFF
--- a/core/src/bytes128.rs
+++ b/core/src/bytes128.rs
@@ -13,8 +13,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-/// `Bytes128` type, and its validation tests.
-use alloc::prelude::v1::*;
+//! `Bytes128` type, and its validation tests.
+
+use alloc::vec::Vec;
 use core::convert::TryFrom;
 use parity_scale_codec::{Decode, Encode, Error as CodecError, Input};
 

--- a/core/src/id.rs
+++ b/core/src/id.rs
@@ -18,7 +18,7 @@
 //! [orgs spec](https://github.com/radicle-dev/registry-spec/blob/0b7699ac597bd935b13facc9152789d111e138ca/body.tex#L110-L119)
 //! [user spec](https://github.com/radicle-dev/registry-spec/blob/1b7699ac597bd935b13facc9152789d111e138ca/body.tex#L452-L459)
 
-use alloc::prelude::v1::*;
+use alloc::string::{String, ToString};
 use core::convert::{From, Into, TryFrom};
 use parity_scale_codec as codec;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,7 +16,6 @@
 //! Basic types used in the Radicle Registry.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(alloc_prelude)]
 
 extern crate alloc;
 

--- a/core/src/project_name.rs
+++ b/core/src/project_name.rs
@@ -13,10 +13,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-/// The name associated to a [`Project`].
-///
-/// https://github.com/radicle-dev/registry-spec/blob/master/body.tex#L306
-use alloc::prelude::v1::*;
+//! The name associated to a project.
+//!
+//! https://github.com/radicle-dev/registry-spec/blob/master/body.tex#L306
+
+use alloc::string::{String, ToString};
 use core::convert::{From, Into, TryFrom};
 use parity_scale_codec as codec;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,7 +21,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
-#![feature(alloc_prelude)]
 
 #[cfg(all(feature = "std", feature = "no-std"))]
 std::compile_error!("Features \"std\" and \"no-std\" cannot be enabled simultaneously. Maybe a dependency implicitly enabled the \"std\" feature.");

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use alloc::prelude::v1::*;
+use alloc::vec::Vec;
 use frame_support::{construct_runtime, parameter_types, weights::Weight};
 use frame_system as system;
 use radicle_registry_core::{state::AccountTransactionIndex, Balance};


### PR DESCRIPTION
Removes unnecessary `alloc_prelude` feature usage.

Now there's no need to compile with the nightly compiler except dependency on `radicle_registry_runtime_v11`.