### PR TITLE
Set block rewards to 20 RAD

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,11 +48,17 @@ pub type Hashing = BlakeTwo256;
 /// Each account has an associated [state::AccountBalance] and [state::AccountTransactionIndex].
 pub type AccountId = ed25519::Public;
 
+/// Amout of currency denominated in μRAD.
+///
 /// The non-negative balance of anything storing the amount of currency.
 /// It can be used to represent the value of anything describing an amount,
 /// e.g. an account balance, the value of a fee, etc.
-/// Represents a μRAD.
 pub type Balance = u128;
+
+/// Convert amount of RAD into balance denominated in μRAD.
+pub const fn rad_to_balance(rad: u64) -> Balance {
+    rad as u128 * 1_000_000
+}
 
 /// The id of a project. Used as storage key.
 pub type ProjectId = (ProjectName, ProjectDomain);

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -61,7 +61,7 @@ where
 }
 
 /// Funds that are credited to the block author for every block.
-pub const BLOCK_REWARD: Balance = 1000;
+pub const BLOCK_REWARD: Balance = rad_to_balance(20);
 
 // Placeholder data to be exported by the client so we can implement the UI in
 // Upstream.


### PR DESCRIPTION
Set block rewards to 20 and add a utility function for getting the balance in μRAD from RAD.