### PR TITLE
Run master builds also on agent preview

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -21,6 +21,13 @@ steps:
     concurrency: 1
     concurrency_group: master
     <<: *test
+  - label: "Test on preview"
+    branches: master
+    concurrency: 1
+    concurrency_group: master
+    agents:
+      queue: agent-preview
+    <<: *test
   - branches: "!master"
     <<: *test
   - wait


### PR DESCRIPTION
We build master also on agents that are running the preview version of our CI setup. This allows us to test the new setup more thoroughly