### PR TITLE
Fix get_id_status

### DIFF
--- a/client/src/interface.rs
+++ b/client/src/interface.rs
@@ -63,6 +63,20 @@ pub struct TransactionIncluded<Message_: Message> {
 /// Return type for all [ClientT] methods.
 pub type Response<T, Error> = BoxFuture<'static, Result<T, Error>>;
 
+/// The availability status of an org or user Id
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IdStatus {
+    /// The id is available and can be claimed
+    Available,
+
+    /// The id is curently taken by a user or by an org
+    Taken,
+
+    /// The id has been unregistered and is now retired
+    Retired,
+}
+
 /// Trait for ledger clients sending transactions and looking up state.
 #[async_trait::async_trait]
 pub trait ClientT {
@@ -130,7 +144,7 @@ pub trait ClientT {
 
     async fn free_balance(&self, account_id: &AccountId) -> Result<Balance, Error>;
 
-    async fn get_id_status(&self, id: &Id) -> IdStatus;
+    async fn get_id_status(&self, id: &Id) -> Result<IdStatus, Error>;
 
     async fn get_org(&self, org_id: Id) -> Result<Option<state::Orgs1Data>, Error>;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -80,18 +80,3 @@ impl ProjectDomain {
 }
 
 pub type CheckpointId = H256;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
-/// The Status of an org or user Id
-pub enum IdStatus {
-    /// The id is available and can be claimed
-    Available,
-
-    /// The id is curently taken by a user or by an org
-    Taken,
-
-    /// The id has been unregistered and is now retired
-    Retired,
-}

--- a/runtime-tests/tests/id_status.rs
+++ b/runtime-tests/tests/id_status.rs
@@ -1,0 +1,89 @@
+// Radicle Registry
+// Copyright (C) 2019 Monadic GmbH <radicle@monadic.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/// Runtime tests implemented with [MemoryClient].
+///
+/// High-level runtime tests that only use [MemoryClient] and treat the runtime as a black box.
+///
+/// The tests in this module concern orgs registration.
+use radicle_registry_client::*;
+use radicle_registry_test_utils::*;
+
+#[async_std::test]
+async fn test_available() {
+    let (client, _) = Client::new_emulator();
+    let status = client.get_id_status(&random_id()).await.unwrap();
+
+    assert_eq!(status, IdStatus::Available);
+}
+
+/// Test that an Id is Taken by an org
+#[async_std::test]
+async fn test_taken_by_org() {
+    let (client, _) = Client::new_emulator();
+    let (author, _) = key_pair_with_associated_user(&client).await;
+    let (org_id, _) = register_random_org(&client, &author).await;
+
+    let status = client.get_id_status(&org_id).await.unwrap();
+    assert_eq!(status, IdStatus::Taken);
+}
+
+/// Test that an Id is Taken by a user
+#[async_std::test]
+async fn test_taken_by_user() {
+    let (client, _) = Client::new_emulator();
+    let (_, user_id) = key_pair_with_associated_user(&client).await;
+
+    let status = client.get_id_status(&user_id).await.unwrap();
+    assert_eq!(status, IdStatus::Taken);
+}
+
+/// Test that an Id is Retired once unregistered by an org
+#[async_std::test]
+async fn test_retired_by_org() {
+    let (client, _) = Client::new_emulator();
+    let (author, _) = key_pair_with_associated_user(&client).await;
+
+    // Register org
+    let (org_id, _) = register_random_org(&client, &author).await;
+
+    // Unregister org
+    let unregister_org_message = message::UnregisterOrg {
+        org_id: org_id.clone(),
+    };
+    let tx_unregister_applied = submit_ok(&client, &author, unregister_org_message.clone()).await;
+    assert_eq!(tx_unregister_applied.result, Ok(()));
+
+    let status = client.get_id_status(&org_id).await.unwrap();
+    assert_eq!(status, IdStatus::Retired);
+}
+
+/// Test that an Id is Retired once unregistered by a user
+#[async_std::test]
+async fn test_retired_by_user() {
+    let (client, _) = Client::new_emulator();
+    // Register user
+    let (author, user_id) = key_pair_with_associated_user(&client).await;
+
+    // Unregister user
+    let unregister_user_message = message::UnregisterUser {
+        user_id: user_id.clone(),
+    };
+    let tx_unregister_applied = submit_ok(&client, &author, unregister_user_message.clone()).await;
+    assert_eq!(tx_unregister_applied.result, Ok(()));
+
+    let status = client.get_id_status(&user_id).await.unwrap();
+    assert_eq!(status, IdStatus::Retired);
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -46,7 +46,7 @@ pub mod registry;
 mod runtime;
 pub mod timestamp_in_digest;
 
-pub use registry::{get_id_status, DecodeKey};
+pub use registry::DecodeKey;
 
 /// An index to a block.
 pub type BlockNumber = u32;

--- a/runtime/src/registry.rs
+++ b/runtime/src/registry.rs
@@ -436,21 +436,13 @@ decl_module! {
     }
 }
 
-pub fn get_id_status(id: &Id) -> IdStatus {
-    if store::Users1::contains_key(id) || store::Orgs1::contains_key(id) {
-        IdStatus::Taken
-    } else if store::RetiredIds1::contains_key(id) {
-        IdStatus::Retired
-    } else {
-        IdStatus::Available
-    }
-}
-
 fn ensure_id_is_available(id: &Id) -> Result<(), RegistryError> {
-    match get_id_status(id) {
-        IdStatus::Available => Ok(()),
-        IdStatus::Taken => Err(RegistryError::IdAlreadyTaken),
-        IdStatus::Retired => Err(RegistryError::IdRetired),
+    if store::Users1::contains_key(id) || store::Orgs1::contains_key(id) {
+        Err(RegistryError::IdAlreadyTaken)
+    } else if store::RetiredIds1::contains_key(id) {
+        Err(RegistryError::IdRetired)
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Currently, calling Client::get_id_status fails because it delegates to
runtime::get_id_status, which - in this context - runs outside an
externalities environment, making access to the storage fail to
happen. The solution here is about moving the logic to the client by
looking up the storage via the backend, just like we do for all other
storage lookups from the client, with the addition of a new fn to check
whether a given key exists in a specific store. Here we also move the
IdStatus definition to the client since it became the only placed where
it is used.