### PR TITLE
client: Export Ss58Codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Upcoming
 
 ### Addition
 
+* client: Add `parse_ss58_address` to parse an `AccountId` from a ss58 formatted string
 * client: Add `account_exists` to check whether an account exists on chain
 * client: Add `fn get_id_status` to get the status of an id (available, taken or retired)
 * Support user project registration

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -344,6 +344,11 @@ impl ClientT for Client {
     }
 }
 
+/// Parse an [AccountId] from str expected to be in the ss58 format, failing otherwise.
+pub fn parse_ss58_address(address: &str) -> Result<AccountId, sp_core::crypto::PublicError> {
+    sp_core::crypto::Ss58Codec::from_ss58check(address)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Tell me if I'm mistaken, but this seems to be the Rusty way of doing it. I'd prefer to have a `parse_ss58_address(&str) -> AccountId` function that would encapsulate that logic instead of exposing the internals and have third clients using the underlying trait to get it right. What do you recon @CodeSandwich? 