### PR TITLE
Run CI build on master

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -21,13 +21,13 @@ steps:
     concurrency: 1
     concurrency_group: master
     <<: *test
-  - label: "Test on preview"
-    branches: master
+  - branches: master
     concurrency: 1
     concurrency_group: master
+    <<: *test
+    label: "Test on preview"
     agents:
       queue: agent-preview
-    <<: *test
   - branches: "!master"
     <<: *test
   - wait


### PR DESCRIPTION
We fix a bug that did not run the master branch build properly on a preview agent.